### PR TITLE
Add support for Linux NVMe SSDs

### DIFF
--- a/linux/CLI/nbproject/Makefile-Debug_i686.mk
+++ b/linux/CLI/nbproject/Makefile-Debug_i686.mk
@@ -53,7 +53,9 @@ OBJECTFILES= \
 	${OBJECTDIR}/_ext/843399383/hmac-sha1.o \
 	${OBJECTDIR}/_ext/843399383/memxor.o \
 	${OBJECTDIR}/_ext/843399383/sha1.o \
-	${OBJECTDIR}/_ext/1472/MsedDevOS.o
+	${OBJECTDIR}/_ext/1472/MsedDevOS.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o
 
 
 # C Compiler Flags
@@ -174,6 +176,16 @@ ${OBJECTDIR}/_ext/1472/MsedDevOS.o: ../MsedDevOS.cpp
 	${MKDIR} -p ${OBJECTDIR}/_ext/1472
 	${RM} "$@.d"
 	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevOS.o ../MsedDevOS.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o: ../MsedDevLinuxSata.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o ../MsedDevLinuxSata.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o: ../MsedDevLinuxNvme.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o ../MsedDevLinuxNvme.cpp
 
 # Subprojects
 .build-subprojects:

--- a/linux/CLI/nbproject/Makefile-Debug_x86_64.mk
+++ b/linux/CLI/nbproject/Makefile-Debug_x86_64.mk
@@ -53,7 +53,9 @@ OBJECTFILES= \
 	${OBJECTDIR}/_ext/843399383/hmac-sha1.o \
 	${OBJECTDIR}/_ext/843399383/memxor.o \
 	${OBJECTDIR}/_ext/843399383/sha1.o \
-	${OBJECTDIR}/_ext/1472/MsedDevOS.o
+	${OBJECTDIR}/_ext/1472/MsedDevOS.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o
 
 
 # C Compiler Flags
@@ -174,6 +176,16 @@ ${OBJECTDIR}/_ext/1472/MsedDevOS.o: ../MsedDevOS.cpp
 	${MKDIR} -p ${OBJECTDIR}/_ext/1472
 	${RM} "$@.d"
 	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevOS.o ../MsedDevOS.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o: ../MsedDevLinuxSata.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o ../MsedDevLinuxSata.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o: ../MsedDevLinuxNvme.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o ../MsedDevLinuxNvme.cpp
 
 # Subprojects
 .build-subprojects:

--- a/linux/CLI/nbproject/Makefile-Release_i686.mk
+++ b/linux/CLI/nbproject/Makefile-Release_i686.mk
@@ -53,7 +53,9 @@ OBJECTFILES= \
 	${OBJECTDIR}/_ext/843399383/hmac-sha1.o \
 	${OBJECTDIR}/_ext/843399383/memxor.o \
 	${OBJECTDIR}/_ext/843399383/sha1.o \
-	${OBJECTDIR}/_ext/1472/MsedDevOS.o
+	${OBJECTDIR}/_ext/1472/MsedDevOS.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o
 
 
 # C Compiler Flags
@@ -174,6 +176,16 @@ ${OBJECTDIR}/_ext/1472/MsedDevOS.o: ../MsedDevOS.cpp
 	${MKDIR} -p ${OBJECTDIR}/_ext/1472
 	${RM} "$@.d"
 	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevOS.o ../MsedDevOS.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o: ../MsedDevLinuxSata.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o ../MsedDevLinuxSata.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o: ../MsedDevLinuxNvme.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o ../MsedDevLinuxNvme.cpp
 
 # Subprojects
 .build-subprojects:

--- a/linux/CLI/nbproject/Makefile-Release_x86_64.mk
+++ b/linux/CLI/nbproject/Makefile-Release_x86_64.mk
@@ -53,7 +53,9 @@ OBJECTFILES= \
 	${OBJECTDIR}/_ext/843399383/hmac-sha1.o \
 	${OBJECTDIR}/_ext/843399383/memxor.o \
 	${OBJECTDIR}/_ext/843399383/sha1.o \
-	${OBJECTDIR}/_ext/1472/MsedDevOS.o
+	${OBJECTDIR}/_ext/1472/MsedDevOS.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o \
+	${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o
 
 
 # C Compiler Flags
@@ -174,6 +176,16 @@ ${OBJECTDIR}/_ext/1472/MsedDevOS.o: ../MsedDevOS.cpp
 	${MKDIR} -p ${OBJECTDIR}/_ext/1472
 	${RM} "$@.d"
 	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevOS.o ../MsedDevOS.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o: ../MsedDevLinuxSata.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxSata.o ../MsedDevLinuxSata.cpp
+
+${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o: ../MsedDevLinuxNvme.cpp
+	${MKDIR} -p ${OBJECTDIR}/_ext/1472
+	${RM} "$@.d"
+	$(COMPILE.cc) -Werror -I.. -I../../Common -I../../Common/pbdkf2 -std=c++11 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/_ext/1472/MsedDevLinuxNvme.o ../MsedDevLinuxNvme.cpp
 
 # Subprojects
 .build-subprojects:

--- a/linux/MsedDevLinuxDrive.h
+++ b/linux/MsedDevLinuxDrive.h
@@ -18,18 +18,14 @@ along with msed.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
-#include "MsedDev.h"
-#include "MsedDevLinuxDrive.h"
+#include "MsedStructures.h"
 
-/** Linux specific implementation of MsedDevOS.
+/** virtual implementation for a disk interface-generic disk drive
  */
-class MsedDevOS : public MsedDev {
+class MsedDevLinuxDrive {
 public:
-    /** Default constructor */
-    MsedDevOS();
-    /** Destructor */
-    ~MsedDevOS();
-    /** OS specific initialization.
+    virtual ~MsedDevLinuxDrive( void ) {};
+    /**Initialization.
      * This function should perform the necessary authority and environment checking
      * to allow proper functioning of the program, open the device, perform an ATA
      * identify, add the fields from the identify response to the disk info structure
@@ -37,22 +33,16 @@ public:
      * the disk_info structure
      * @param devref character representation of the device is standard OS lexicon
      */
-    void init(const char * devref);
-    /** OS specific method to send an ATA command to the device
-     * @param cmd ATA command to be sent to the device
+    virtual bool init(const char * devref) = 0;
+    /** Method to send a command to the device
+     * @param cmd command to be sent to the device
      * @param protocol security protocol to be used in the command
      * @param comID communications ID to be used
      * @param buffer input/output buffer
      * @param bufferlen length of the input/output buffer
      */
-    uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
-            void * buffer, uint16_t bufferlen);
-protected:
-    /** OS specific command to Wait for specified number of milliseconds 
-     * @param ms  number of milliseconds to wait
-     */
-    void osmsSleep(uint32_t ms);
-	void identify();
-
-	MsedDevLinuxDrive *drive;
+    virtual uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+            void * buffer, uint16_t bufferlen) = 0;
+    /** Routine to send an identify to the device */
+    virtual void identify(OPAL_DiskInfo *disk_info) = 0;
 };

--- a/linux/MsedDevLinuxNvme.cpp
+++ b/linux/MsedDevLinuxNvme.cpp
@@ -1,0 +1,145 @@
+/* C:B**************************************************************************
+This software is Copyright 2014,2015 Michael Romeo <r0m30@r0m30.com>
+
+This file is part of msed.
+
+msed is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+msed is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with msed.  If not, see <http://www.gnu.org/licenses/>.
+
+ * C:E********************************************************************** */
+#include "os.h"
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <scsi/sg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/hdreg.h>
+#include <errno.h>
+#include <vector>
+#include <fstream>
+#include "MsedDevLinuxNvme.h"
+#include "MsedHexDump.h"
+
+using namespace std;
+
+/** The Device class represents a single disk device.
+ *  Linux specific implementation using the NVMe interface
+ */
+MsedDevLinuxNvme::MsedDevLinuxNvme() {}
+
+bool MsedDevLinuxNvme::init(const char * devref)
+{
+    LOG(D1) << "Creating MsedDevLinuxNvme::MsedDev() " << devref;
+    ifstream kopts;
+    bool isOpen = FALSE;
+
+    if ((fd = open(devref, O_RDWR)) < 0) {
+        isOpen = FALSE;
+        // This is a D1 because diskscan looks for open fail to end scan
+        LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
+        //        if (-EPERM == fd) {
+        //            LOG(E) << "You do not have permission to access the raw disk in write mode";
+        //            LOG(E) << "Perhaps you might try sudo to run as root";
+        //        }
+    }
+    else {
+        isOpen = TRUE;
+    }
+	return isOpen;
+}
+
+/** Send an ioctl to the device using nvme admin commands. */
+uint8_t MsedDevLinuxNvme::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+                         void * buffer, uint16_t bufferlen)
+{
+    struct nvme_admin_cmd nvme_cmd;
+	int err;
+
+    LOG(D1) << "Entering MsedDevOS::sendCmd";
+
+	memset(&nvme_cmd, 0, sizeof(nvme_cmd));
+
+	if (IF_RECV == cmd) {
+		LOG(D3) << "Security Receive Command";
+		nvme_cmd.opcode = nvme_admin_security_recv;
+		nvme_cmd.cdw10 = protocol << 24 | comID << 8;
+		nvme_cmd.cdw11 = bufferlen;
+		nvme_cmd.data_len = bufferlen;
+		nvme_cmd.addr = (__u64)buffer;
+	}
+	else {
+		LOG(D3) << "Security Send Command";
+		nvme_cmd.opcode = nvme_admin_security_send;
+		nvme_cmd.cdw10 = protocol << 24 | comID << 8;
+		nvme_cmd.cdw11 = bufferlen;
+		nvme_cmd.data_len = bufferlen;
+		nvme_cmd.addr = (__u64)buffer;
+	}
+
+	err = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &nvme_cmd);
+	if (err < 0)
+		return errno;
+	else if (err != 0) {
+		fprintf(stderr, "NVME Security Command Error:%d\n", err);
+		IFLOG(D4) MsedHexDump(&nvme_cmd, sizeof(nvme_cmd));
+	}
+	else
+		LOG(D3) << "NVME Security Command Success:" << nvme_cmd.result;
+	//LOG(D4) << "NVMe command:";
+	//IFLOG(D4) MsedHexDump(&nvme_cmd, sizeof(nvme_cmd));
+	//LOG(D4) << "NVMe buffer @ " << buffer;
+	//IFLOG(D4) MsedHexDump(buffer, bufferlen);
+	return err;
+}
+
+void MsedDevLinuxNvme::identify(OPAL_DiskInfo *disk_info)
+{
+	LOG(D4) << "Entering MsedDevLinuxNvme::identify()";
+
+	struct nvme_admin_cmd cmd;
+	struct nvme_id_ctrl ctrl;
+	int err;
+
+	memset(&cmd, 0, sizeof(cmd));
+	cmd.opcode = nvme_admin_identify;
+	cmd.nsid = 0;
+	cmd.addr = (unsigned long)&ctrl;
+	cmd.data_len = 4096;
+	cmd.cdw10 = 1;
+	err = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+
+	if (err) {
+		LOG(E) << "Identify error. NVMe status " << err;
+		disk_info->devType = 1;
+		IFLOG(D4) MsedHexDump(&cmd, sizeof(cmd));
+		IFLOG(D4) MsedHexDump(&ctrl, sizeof(ctrl));
+		return;
+	}
+
+	disk_info->devType = 0;
+	memcpy(disk_info->serialNum, ctrl.sn, sizeof (disk_info->serialNum));
+	memcpy(disk_info->firmwareRev, ctrl.fr, sizeof(disk_info->firmwareRev));
+	memcpy(disk_info->modelNum, ctrl.mn, sizeof(disk_info->modelNum));
+
+    return;
+}
+
+/** Close the device reference so this object can be delete. */
+MsedDevLinuxNvme::~MsedDevLinuxNvme()
+{
+    LOG(D1) << "Destroying MsedDevLinuxNvme";
+    close(fd);
+}

--- a/linux/MsedDevLinuxNvme.cpp
+++ b/linux/MsedDevLinuxNvme.cpp
@@ -68,7 +68,7 @@ uint8_t MsedDevLinuxNvme::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t com
     struct nvme_admin_cmd nvme_cmd;
 	int err;
 
-    LOG(D1) << "Entering MsedDevOS::sendCmd";
+    LOG(D1) << "Entering MsedDevLinuxNvme::sendCmd";
 
 	memset(&nvme_cmd, 0, sizeof(nvme_cmd));
 

--- a/linux/MsedDevLinuxNvme.h
+++ b/linux/MsedDevLinuxNvme.h
@@ -18,18 +18,23 @@ along with msed.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
-#include "MsedDev.h"
+#include "linux/nvme.h"
+#include "MsedStructures.h"
 #include "MsedDevLinuxDrive.h"
 
 /** Linux specific implementation of MsedDevOS.
+ * Uses the NVMe to send commands to the 
+ * device 
  */
-class MsedDevOS : public MsedDev {
+#define is_aligned(POINTER, BYTE_COUNT) \
+    (((uintptr_t)(const void *)(POINTER)) % (BYTE_COUNT) == 0)
+class MsedDevLinuxNvme: public MsedDevLinuxDrive{
 public:
     /** Default constructor */
-    MsedDevOS();
+    MsedDevLinuxNvme();
     /** Destructor */
-    ~MsedDevOS();
-    /** OS specific initialization.
+    ~MsedDevLinuxNvme();
+    /** NVMe specific initialization.
      * This function should perform the necessary authority and environment checking
      * to allow proper functioning of the program, open the device, perform an ATA
      * identify, add the fields from the identify response to the disk info structure
@@ -37,9 +42,9 @@ public:
      * the disk_info structure
      * @param devref character representation of the device is standard OS lexicon
      */
-    void init(const char * devref);
-    /** OS specific method to send an ATA command to the device
-     * @param cmd ATA command to be sent to the device
+    bool init(const char * devref);
+    /** NVMe specific method to send a command to the device
+     * @param cmd command to be sent to the device
      * @param protocol security protocol to be used in the command
      * @param comID communications ID to be used
      * @param buffer input/output buffer
@@ -47,12 +52,7 @@ public:
      */
     uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
             void * buffer, uint16_t bufferlen);
-protected:
-    /** OS specific command to Wait for specified number of milliseconds 
-     * @param ms  number of milliseconds to wait
-     */
-    void osmsSleep(uint32_t ms);
-	void identify();
-
-	MsedDevLinuxDrive *drive;
+    /** NVMe specific routine to send an identify to the device */
+    void identify(OPAL_DiskInfo *disk_info);
+    int fd; /**< Linux handle for the device  */
 };

--- a/linux/MsedDevLinuxSata.cpp
+++ b/linux/MsedDevLinuxSata.cpp
@@ -47,7 +47,7 @@ bool MsedDevLinuxSata::init(const char * devref)
     LOG(D1) << "Creating MsedDevLinuxSata::MsedDev() " << devref;
     ifstream kopts;
 	bool isOpen = FALSE;
-    
+
     if(access("/dev/sda", R_OK | W_OK)) {
         LOG(E) << "You do not have permission to access the raw disk in write mode";
         LOG(E) << "Perhaps you might try sudo to run as root";
@@ -61,9 +61,9 @@ bool MsedDevLinuxSata::init(const char * devref)
             LOG(E) << "The Kernel flag libata.allow_tpm is not set correctly";
                LOG(E) << "Please see the readme note about setting the libata.allow_tpm ";
         }
-        kopts.close();   
+        kopts.close();
     }
-    
+
     if ((fd = open(devref, O_RDWR)) < 0) {
         isOpen = FALSE;
         // This is a D1 because diskscan looks for open fail to end scan
@@ -87,7 +87,7 @@ uint8_t MsedDevLinuxSata::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t com
     uint8_t sense[32]; // how big should this be??
     uint8_t cdb[12];
 
-    LOG(D1) << "Entering MsedDevOS::sendCmd";
+    LOG(D1) << "Entering MsedDevLinuxSata::sendCmd";
     memset(&cdb, 0, sizeof (cdb));
     memset(&sense, 0, sizeof (sense));
     memset(&sg, 0, sizeof (sg));

--- a/linux/MsedDevLinuxSata.cpp
+++ b/linux/MsedDevLinuxSata.cpp
@@ -1,0 +1,216 @@
+/* C:B**************************************************************************
+This software is Copyright 2014,2015 Michael Romeo <r0m30@r0m30.com>
+
+This file is part of msed.
+
+msed is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+msed is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with msed.  If not, see <http://www.gnu.org/licenses/>.
+
+ * C:E********************************************************************** */
+#include "os.h"
+#include <malloc.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <scsi/sg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/hdreg.h>
+#include <errno.h>
+#include <vector>
+#include <fstream>
+#include "MsedDevLinuxSata.h"
+#include "MsedHexDump.h"
+
+using namespace std;
+
+/** The Device class represents a single disk device.
+ *  Linux specific implementation using the SCSI generic interface and
+ *  SCSI ATA Pass Through (12) command
+ */
+MsedDevLinuxSata::MsedDevLinuxSata() {}
+
+bool MsedDevLinuxSata::init(const char * devref)
+{
+    LOG(D1) << "Creating MsedDevLinuxSata::MsedDev() " << devref;
+    ifstream kopts;
+	bool isOpen = FALSE;
+    
+    if(access("/dev/sda", R_OK | W_OK)) {
+        LOG(E) << "You do not have permission to access the raw disk in write mode";
+        LOG(E) << "Perhaps you might try sudo to run as root";
+    }
+    kopts.open("/sys/module/libata/parameters/allow_tpm", ios::in);
+    if (!kopts) {
+	LOG(W) << "Unable to verify Kernel flag libata.allow_tpm ";
+    } 
+    else {
+        if('1' !=  kopts.get()) {
+            LOG(E) << "The Kernel flag libata.allow_tpm is not set correctly";
+               LOG(E) << "Please see the readme note about setting the libata.allow_tpm ";
+        }
+        kopts.close();   
+    }
+    
+    if ((fd = open(devref, O_RDWR)) < 0) {
+        isOpen = FALSE;
+        // This is a D1 because diskscan looks for open fail to end scan
+        LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
+        //        if (-EPERM == fd) {
+        //            LOG(E) << "You do not have permission to access the raw disk in write mode";
+        //            LOG(E) << "Perhaps you might try sudo to run as root";
+        //        }
+    }
+    else {
+        isOpen = TRUE;
+    }
+	return isOpen;
+}
+
+/** Send an ioctl to the device using pass through. */
+uint8_t MsedDevLinuxSata::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+                         void * buffer, uint16_t bufferlen)
+{
+    sg_io_hdr_t sg;
+    uint8_t sense[32]; // how big should this be??
+    uint8_t cdb[12];
+
+    LOG(D1) << "Entering MsedDevOS::sendCmd";
+    memset(&cdb, 0, sizeof (cdb));
+    memset(&sense, 0, sizeof (sense));
+    memset(&sg, 0, sizeof (sg));
+    /*
+     * Initialize the CDB as described in SAT-2 and the
+     * ATA Command set reference (protocol and commID placement)
+     * We need a few more standards bodies --NOT--
+     */
+
+    cdb[0] = 0xa1; // ata pass through(12)
+    /*
+     * Byte 1 is the protocol 4 = PIO IN and 5 = PIO OUT
+     * Byte 2 is:
+     * bits 7-6 OFFLINE - Amount of time the command can take the bus offline
+     * bit 5    CK_COND - If set the command will always return a condition check
+     * bit 4    RESERVED
+     * bit 3    T_DIR   - transfer direction 1 in, 0 out
+     * bit 2    BYTE_BLock  1 = transfer in blocks, 0 transfer in bytes
+     * bits 1-0 T_LENGTH -  10 = the length id in sector count
+     */
+    if (IF_RECV == cmd) {
+        cdb[1] = 4 << 1; // PIO DATA IN
+        cdb[2] = 0x0E; // T_DIR = 1, BYTE_BLOCK = 1, Length in Sector Count
+        sg.dxfer_direction = SG_DXFER_FROM_DEV;
+    }
+    else {
+        cdb[1] = 5 << 1; // PIO DATA OUT
+        cdb[2] = 0x06; // T_DIR = 0, BYTE_BLOCK = 1, Length in Sector Count
+        sg.dxfer_direction = SG_DXFER_TO_DEV;
+    }
+    cdb[3] = protocol; // ATA features / TRUSTED S/R security protocol
+    cdb[4] = bufferlen / 512; // Sector count / transfer length (512b blocks)
+    //      cdb[5] = reserved;
+    cdb[7] = ((comID & 0xff00) >> 8);
+    cdb[6] = (comID & 0x00ff);
+    //      cdb[8] = 0x00;              // device
+    cdb[9] = cmd; // IF_SEND/IF_RECV
+    //      cdb[10] = 0x00;              // reserved
+    //      cdb[11] = 0x00;              // control
+    /*
+     * Set up the SCSI Generic structure
+     * see the SG HOWTO for the best info I could find
+     */
+    sg.interface_id = 'S';
+    //      sg.dxfer_direction = Set in if above
+    sg.cmd_len = sizeof (cdb);
+    sg.mx_sb_len = sizeof (sense);
+    sg.iovec_count = 0;
+    sg.dxfer_len = IO_BUFFER_LENGTH;
+    sg.dxferp = buffer;
+    sg.cmdp = cdb;
+    sg.sbp = sense;
+    sg.timeout = 5000;
+    sg.flags = 0;
+    sg.pack_id = 0;
+    sg.usr_ptr = NULL;
+    //    LOG(D4) << "cdb before ";
+    //    IFLOG(D4) hexDump(cdb, sizeof (cdb));
+    //    LOG(D4) << "sg before ";
+    //    IFLOG(D4) hexDump(&sg, sizeof (sg));
+    /*
+     * Do the IO
+     */
+    if (ioctl(fd, SG_IO, &sg) < 0) {
+        LOG(D4) << "cdb after ";
+        IFLOG(D4) MsedHexDump(cdb, sizeof (cdb));
+        LOG(D4) << "sense after ";
+        IFLOG(D4) MsedHexDump(sense, sizeof (sense));
+        return 0xff;
+    }
+    //    LOG(D4) << "cdb after ";
+    //    IFLOG(D4) hexDump(cdb, sizeof (cdb));
+    //    LOG(D4) << "sg after ";
+    //    IFLOG(D4) hexDump(&sg, sizeof (sg));
+    //    LOG(D4) << "sense after ";
+    //    IFLOG(D4) hexDump(sense, sizeof (sense));
+    if (!((0x00 == sense[0]) && (0x00 == sense[1])))
+        if (!((0x72 == sense[0]) && (0x0b == sense[1]))) return 0xff; // not ATA response
+    return (sense[11]);
+}
+
+void MsedDevLinuxSata::identify(OPAL_DiskInfo *disk_info)
+{
+    LOG(D4) << "Entering MsedDevLinuxSata::identify()";
+    vector<uint8_t> nullz(512, 0x00);
+    uint8_t * buffer = (uint8_t *) memalign(IO_BUFFER_ALIGNMENT, IO_BUFFER_LENGTH);
+    memset(buffer, 0, IO_BUFFER_LENGTH);
+    if (ioctl(fd, HDIO_GET_IDENTITY, buffer) < 0) {
+        LOG(E) << "Identify failed " << strerror(errno);
+        disk_info->devType = 1;
+        return;
+    }
+
+    if (!(memcmp(nullz.data(), buffer, 512))) {
+        disk_info->devType = 1;
+        return;
+    }
+    IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;
+    disk_info->devType = id->devType;
+    memcpy(disk_info->serialNum, id->serialNum, sizeof (disk_info->serialNum));
+    memcpy(disk_info->firmwareRev, id->firmwareRev, sizeof (disk_info->firmwareRev));
+    memcpy(disk_info->modelNum, id->modelNum, sizeof (disk_info->modelNum));
+    // looks like linux does the byte flipping for you
+    //    for (int i = 0; i < sizeof (disk_info.serialNum); i += 2) {
+    //        disk_info.serialNum[i] = id->serialNum[i + 1];
+    //        disk_info.serialNum[i + 1] = id->serialNum[i];
+    //    }
+    //    for (int i = 0; i < sizeof (disk_info.firmwareRev); i += 2) {
+    //        disk_info.firmwareRev[i] = id->firmwareRev[i + 1];
+    //        disk_info.firmwareRev[i + 1] = id->firmwareRev[i];
+    //    }
+    //    for (int i = 0; i < sizeof (disk_info.modelNum); i += 2) {
+    //        disk_info.modelNum[i] = id->modelNum[i + 1];
+    //        disk_info.modelNum[i + 1] = id->modelNum[i];
+    //    }
+
+    free(buffer);
+    return;
+}
+
+/** Close the device reference so this object can be delete. */
+MsedDevLinuxSata::~MsedDevLinuxSata()
+{
+    LOG(D1) << "Destroying MsedDevLinuxSata";
+    close(fd);
+}

--- a/linux/MsedDevLinuxSata.h
+++ b/linux/MsedDevLinuxSata.h
@@ -18,18 +18,20 @@ along with msed.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
-#include "MsedDev.h"
+#include "MsedStructures.h"
 #include "MsedDevLinuxDrive.h"
 
 /** Linux specific implementation of MsedDevOS.
+ * Uses the SCSI generic ioctls to send commands to the 
+ * device 
  */
-class MsedDevOS : public MsedDev {
+class MsedDevLinuxSata: public MsedDevLinuxDrive {
 public:
     /** Default constructor */
-    MsedDevOS();
+    MsedDevLinuxSata();
     /** Destructor */
-    ~MsedDevOS();
-    /** OS specific initialization.
+    ~MsedDevLinuxSata();
+    /** Sata Linux specific initialization.
      * This function should perform the necessary authority and environment checking
      * to allow proper functioning of the program, open the device, perform an ATA
      * identify, add the fields from the identify response to the disk info structure
@@ -37,8 +39,8 @@ public:
      * the disk_info structure
      * @param devref character representation of the device is standard OS lexicon
      */
-    void init(const char * devref);
-    /** OS specific method to send an ATA command to the device
+    bool init(const char * devref);
+    /** Sata Linux specific method to send an ATA command to the device
      * @param cmd ATA command to be sent to the device
      * @param protocol security protocol to be used in the command
      * @param comID communications ID to be used
@@ -47,12 +49,7 @@ public:
      */
     uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
             void * buffer, uint16_t bufferlen);
-protected:
-    /** OS specific command to Wait for specified number of milliseconds 
-     * @param ms  number of milliseconds to wait
-     */
-    void osmsSleep(uint32_t ms);
-	void identify();
-
-	MsedDevLinuxDrive *drive;
+    /** Linux specific routine to send an ATA identify to the device */
+    void identify(OPAL_DiskInfo *disk_info);
+	int fd; /**< Linux handle for the device  */
 };

--- a/linux/MsedDevOS.cpp
+++ b/linux/MsedDevOS.cpp
@@ -86,10 +86,10 @@ uint8_t MsedDevOS::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 
 	if (NULL == drive)
 	{
-		LOG(E) << "MsedDevOS::init ERROR - unknown drive type";
+		LOG(E) << "MsedDevOS::sendCmd ERROR - unknown drive type";
 		return 0xff;
 	}
-	
+
 	return drive->sendCmd(cmd, protocol, comID, buffer, bufferlen);
 }
 
@@ -101,7 +101,7 @@ void MsedDevOS::identify()
 		LOG(E) << "MsedDevOS::identify ERROR - unknown disk type";
 		return;
 	}
-	
+
 	drive->identify(&disk_info);
 }
 
@@ -114,7 +114,7 @@ void MsedDevOS::osmsSleep(uint32_t ms)
 /** Close the device reference so this object can be delete. */
 MsedDevOS::~MsedDevOS()
 {
-    LOG(D1) << "Destroying MsedDev";
+    LOG(D1) << "Destroying MsedDevOS";
 	if (NULL != drive)
 		delete drive;
 }

--- a/linux/MsedDevOS.cpp
+++ b/linux/MsedDevOS.cpp
@@ -18,7 +18,6 @@ along with msed.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #include "os.h"
-#include <malloc.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -33,190 +32,82 @@ along with msed.  If not, see <http://www.gnu.org/licenses/>.
 #include <fstream>
 #include "MsedDevOS.h"
 #include "MsedHexDump.h"
+#include "MsedDevLinuxSata.h"
+#include "MsedDevLinuxNvme.h"
 
 using namespace std;
 
-/** The Device class represents a single disk device.
- *  Linux specific implementation using the SCSI generic interface and
- *  SCSI ATA Pass Through (12) command
+/** The Device class represents a Linux generic storage device.
+  * At initialization we determine if we map to the NVMe or SATA derived class
  */
-MsedDevOS::MsedDevOS() {}
-
-void MsedDevOS::init(const char * devref)
+MsedDevOS::MsedDevOS()
 {
-    LOG(D1) << "Creating MsedDevOS::MsedDev() " << devref;
-    dev = devref;
-    ifstream kopts;
-    
-    if(access("/dev/sda", R_OK | W_OK)) {
-        LOG(E) << "You do not have permission to access the raw disk in write mode";
-        LOG(E) << "Perhaps you might try sudo to run as root";
-    }
-    kopts.open("/sys/module/libata/parameters/allow_tpm", ios::in);
-    if (!kopts) {
-	LOG(W) << "Unable to verify Kernel flag libata.allow_tpm ";
-    } 
-    else {
-        if('1' !=  kopts.get()) {
-            LOG(E) << "The Kernel flag libata.allow_tpm is not set correctly";
-               LOG(E) << "Please see the readme note about setting the libata.allow_tpm ";
-        }
-        kopts.close();   
-    }
-    
-    memset(&disk_info, 0, sizeof (OPAL_DiskInfo));
-    if ((fd = open(dev, O_RDWR)) < 0) {
-        isOpen = FALSE;
-        // This is a D1 because diskscan looks for open fail to end scan
-        LOG(D1) << "Error opening device " << dev << " " << (int32_t) fd;
-        //        if (-EPERM == fd) {
-        //            LOG(E) << "You do not have permission to access the raw disk in write mode";
-        //            LOG(E) << "Perhaps you might try sudo to run as root";
-        //        }
-    }
-    else {
-        isOpen = TRUE;
-
-        identify();
-        if (!disk_info.devType) discovery0();
-    }
+	drive = NULL;
 }
 
-/** Send an ioctl to the device using pass through. */
-uint8_t MsedDevOS::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
-                         void * buffer, uint16_t bufferlen)
+/* Determine which type of drive we're using and instantiate a derived class of that type */
+void MsedDevOS::init(const char * devref)
 {
-    sg_io_hdr_t sg;
-    uint8_t sense[32]; // how big should this be??
-    uint8_t cdb[12];
+	LOG(D1) << "MsedDevOS::init " << devref;
 
-    LOG(D1) << "Entering MsedDevOS::sendCmd";
-    if (!isOpen) return 0xfe; //disk open failed so this will too
-    memset(&cdb, 0, sizeof (cdb));
-    memset(&sense, 0, sizeof (sense));
-    memset(&sg, 0, sizeof (sg));
-    /*
-     * Initialize the CDB as described in SAT-2 and the
-     * ATA Command set reference (protocol and commID placement)
-     * We need a few more standards bodies --NOT--
-     */
+	memset(&disk_info, 0, sizeof(OPAL_DiskInfo));
+	dev = devref;
 
-    cdb[0] = 0xa1; // ata pass through(12)
-    /*
-     * Byte 1 is the protocol 4 = PIO IN and 5 = PIO OUT
-     * Byte 2 is:
-     * bits 7-6 OFFLINE - Amount of time the command can take the bus offline
-     * bit 5    CK_COND - If set the command will always return a condition check
-     * bit 4    RESERVED
-     * bit 3    T_DIR   - transfer direction 1 in, 0 out
-     * bit 2    BYTE_BLock  1 = transfer in blocks, 0 transfer in bytes
-     * bits 1-0 T_LENGTH -  10 = the length id in sector count
-     */
-    if (IF_RECV == cmd) {
-        cdb[1] = 4 << 1; // PIO DATA IN
-        cdb[2] = 0x0E; // T_DIR = 1, BYTE_BLOCK = 1, Length in Sector Count
-        sg.dxfer_direction = SG_DXFER_FROM_DEV;
-    }
-    else {
-        cdb[1] = 5 << 1; // PIO DATA OUT
-        cdb[2] = 0x06; // T_DIR = 0, BYTE_BLOCK = 1, Length in Sector Count
-        sg.dxfer_direction = SG_DXFER_TO_DEV;
-    }
-    cdb[3] = protocol; // ATA features / TRUSTED S/R security protocol
-    cdb[4] = bufferlen / 512; // Sector count / transfer length (512b blocks)
-    //      cdb[5] = reserved;
-    cdb[7] = ((comID & 0xff00) >> 8);
-    cdb[6] = (comID & 0x00ff);
-    //      cdb[8] = 0x00;              // device
-    cdb[9] = cmd; // IF_SEND/IF_RECV
-    //      cdb[10] = 0x00;              // reserved
-    //      cdb[11] = 0x00;              // control
-    /*
-     * Set up the SCSI Generic structure
-     * see the SG HOWTO for the best info I could find
-     */
-    sg.interface_id = 'S';
-    //      sg.dxfer_direction = Set in if above
-    sg.cmd_len = sizeof (cdb);
-    sg.mx_sb_len = sizeof (sense);
-    sg.iovec_count = 0;
-    sg.dxfer_len = IO_BUFFER_LENGTH;
-    sg.dxferp = buffer;
-    sg.cmdp = cdb;
-    sg.sbp = sense;
-    sg.timeout = 5000;
-    sg.flags = 0;
-    sg.pack_id = 0;
-    sg.usr_ptr = NULL;
-    //    LOG(D4) << "cdb before ";
-    //    IFLOG(D4) hexDump(cdb, sizeof (cdb));
-    //    LOG(D4) << "sg before ";
-    //    IFLOG(D4) hexDump(&sg, sizeof (sg));
-    /*
-     * Do the IO
-     */
-    if (ioctl(fd, SG_IO, &sg) < 0) {
-        LOG(D4) << "cdb after ";
-        IFLOG(D4) MsedHexDump(cdb, sizeof (cdb));
-        LOG(D4) << "sense after ";
-        IFLOG(D4) MsedHexDump(sense, sizeof (sense));
-        return 0xff;
-    }
-    //    LOG(D4) << "cdb after ";
-    //    IFLOG(D4) hexDump(cdb, sizeof (cdb));
-    //    LOG(D4) << "sg after ";
-    //    IFLOG(D4) hexDump(&sg, sizeof (sg));
-    //    LOG(D4) << "sense after ";
-    //    IFLOG(D4) hexDump(sense, sizeof (sense));
-    if (!((0x00 == sense[0]) && (0x00 == sense[1])))
-        if (!((0x72 == sense[0]) && (0x0b == sense[1]))) return 0xff; // not ATA response
-    return (sense[11]);
+	if (!strncmp(devref, "/dev/nvme", 9))
+	{
+		MsedDevLinuxNvme *NvmeDrive = new MsedDevLinuxNvme();
+		drive = NvmeDrive;
+	}
+	else if (!strncmp(devref, "/dev/s", 6))
+	{
+		MsedDevLinuxSata *SataDrive = new MsedDevLinuxSata();
+		drive = SataDrive;
+	}
+	else
+		LOG(E) << "MsedDevOS::init ERROR - unknown drive type";
+
+	if (drive->init(devref))
+	{
+		isOpen = TRUE;
+		drive->identify(&disk_info);
+		if (!disk_info.devType)
+			discovery0();
+	}
+	else
+		isOpen = FALSE;
+
+	return;
+}
+
+uint8_t MsedDevOS::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+	void * buffer, uint16_t bufferlen)
+{
+	if (!isOpen) return 0xfe; //disk open failed so this will too
+
+	if (NULL == drive)
+	{
+		LOG(E) << "MsedDevOS::init ERROR - unknown drive type";
+		return 0xff;
+	}
+	
+	return drive->sendCmd(cmd, protocol, comID, buffer, bufferlen);
 }
 
 void MsedDevOS::identify()
 {
-    LOG(D4) << "Entering MsedDevOS::identify()";
-    vector<uint8_t> nullz(512, 0x00);
-    if (!isOpen) return; //disk open failed so this will too
-    uint8_t * buffer = (uint8_t *) memalign(IO_BUFFER_ALIGNMENT, IO_BUFFER_LENGTH);
-    memset(buffer, 0, IO_BUFFER_LENGTH);
-    if (ioctl(fd, HDIO_GET_IDENTITY, buffer) < 0) {
-        LOG(E) << "Identify failed " << strerror(errno);
-        disk_info.devType = 1;
-        return;
-    }
-
-    if (!(memcmp(nullz.data(), buffer, 512))) {
-        disk_info.devType = 1;
-        return;
-    }
-    IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;
-    disk_info.devType = id->devType;
-    memcpy(disk_info.serialNum, id->serialNum, sizeof (disk_info.serialNum));
-    memcpy(disk_info.firmwareRev, id->firmwareRev, sizeof (disk_info.firmwareRev));
-    memcpy(disk_info.modelNum, id->modelNum, sizeof (disk_info.modelNum));
-    // looks like linux does the byte flipping for you
-    //    for (int i = 0; i < sizeof (disk_info.serialNum); i += 2) {
-    //        disk_info.serialNum[i] = id->serialNum[i + 1];
-    //        disk_info.serialNum[i + 1] = id->serialNum[i];
-    //    }
-    //    for (int i = 0; i < sizeof (disk_info.firmwareRev); i += 2) {
-    //        disk_info.firmwareRev[i] = id->firmwareRev[i + 1];
-    //        disk_info.firmwareRev[i + 1] = id->firmwareRev[i];
-    //    }
-    //    for (int i = 0; i < sizeof (disk_info.modelNum); i += 2) {
-    //        disk_info.modelNum[i] = id->modelNum[i + 1];
-    //        disk_info.modelNum[i + 1] = id->modelNum[i];
-    //    }
-
-    free(buffer);
-    return;
+	if (!isOpen) return; //disk open failed so this will too
+	if (NULL == drive)
+	{
+		LOG(E) << "MsedDevOS::identify ERROR - unknown disk type";
+		return;
+	}
+	
+	drive->identify(&disk_info);
 }
 
 void MsedDevOS::osmsSleep(uint32_t ms)
 {
-
-    usleep(ms * 1000); //convert to microseconds
+	usleep(ms * 1000); //convert to microseconds
     return;
 }
 
@@ -224,5 +115,6 @@ void MsedDevOS::osmsSleep(uint32_t ms)
 MsedDevOS::~MsedDevOS()
 {
     LOG(D1) << "Destroying MsedDev";
-    close(fd);
+	if (NULL != drive)
+		delete drive;
 }


### PR DESCRIPTION
...by abstracting the concept of drive type.
The MsedDevOS::init() function looks at devref to determine drive type automatically.

Signed-off-by: Jason B Akers <jason.b.akers@intel.com>