### PR TITLE
Use nvme_ioctl.h for newer kernel versions #55

### DIFF
--- a/linux/DtaDevLinuxNvme.h
+++ b/linux/DtaDevLinuxNvme.h
@@ -18,7 +18,13 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
-#include "linux/nvme.h"
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#include <linux/nvme_ioctl.h>
+#include "DtaDevLinuxNvmeStructsOpCodes.h"
+#else
+#include <linux/nvme.h>
+#endif
 #include "DtaStructures.h"
 #include "DtaDevLinuxDrive.h"
 

--- a/linux/DtaDevLinuxNvmeStructsOpCodes.h
+++ b/linux/DtaDevLinuxNvmeStructsOpCodes.h
@@ -1,0 +1,95 @@
+/*
+ * Definitions for the NVM Express interface
+ * Copyright (c) 2011-2014, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#pragma once
+
+enum nvme_admin_opcode {
+        nvme_admin_delete_sq            = 0x00,
+        nvme_admin_create_sq            = 0x01,
+        nvme_admin_get_log_page         = 0x02,
+        nvme_admin_delete_cq            = 0x04,
+        nvme_admin_create_cq            = 0x05,
+        nvme_admin_identify             = 0x06,
+        nvme_admin_abort_cmd            = 0x08,
+        nvme_admin_set_features         = 0x09,
+        nvme_admin_get_features         = 0x0a,
+        nvme_admin_async_event          = 0x0c,
+        nvme_admin_activate_fw          = 0x10,
+        nvme_admin_download_fw          = 0x11,
+        nvme_admin_format_nvm           = 0x80,
+        nvme_admin_security_send        = 0x81,
+        nvme_admin_security_recv        = 0x82,
+};
+
+struct nvme_id_power_state {
+        __le16                  max_power;      /* centiwatts */
+        __u8                    rsvd2;
+        __u8                    flags;
+        __le32                  entry_lat;      /* microseconds */
+        __le32                  exit_lat;       /* microseconds */
+        __u8                    read_tput;
+        __u8                    read_lat;
+        __u8                    write_tput;
+        __u8                    write_lat;
+        __le16                  idle_power;
+        __u8                    idle_scale;
+        __u8                    rsvd19;
+        __le16                  active_power;
+        __u8                    active_work_scale;
+        __u8                    rsvd23[9];
+};
+
+struct nvme_id_ctrl {
+        __le16                  vid;
+        __le16                  ssvid;
+        char                    sn[20];
+        char                    mn[40];
+        char                    fr[8];
+        __u8                    rab;
+        __u8                    ieee[3];
+        __u8                    mic;
+        __u8                    mdts;
+        __le16                  cntlid;
+        __le32                  ver;
+        __u8                    rsvd84[172];
+        __le16                  oacs;
+        __u8                    acl;
+        __u8                    aerl;
+        __u8                    frmw;
+        __u8                    lpa;
+        __u8                    elpe;
+        __u8                    npss;
+        __u8                    avscc;
+        __u8                    apsta;
+        __le16                  wctemp;
+        __le16                  cctemp;
+        __u8                    rsvd270[242];
+        __u8                    sqes;
+        __u8                    cqes;
+        __u8                    rsvd514[2];
+        __le32                  nn;
+        __le16                  oncs;
+        __le16                  fuses;
+        __u8                    fna;
+        __u8                    vwc;
+        __le16                  awun;
+        __le16                  awupf;
+        __u8                    nvscc;
+        __u8                    rsvd531;
+        __le16                  acwu;
+        __u8                    rsvd534[2];
+        __le32                  sgls;
+        __u8                    rsvd540[1508];
+        struct nvme_id_power_state      psd[32];
+        __u8                    vs[1024];
+};


### PR DESCRIPTION
The header linux/nvme.h was replaced by linux/nvme_ioctl.h in kernel versions greater than 4.4: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=9d99a8dda154

See also:
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a9cf8284b45110a4d98aea180a89c857e53bf850
https://www.bountysource.com/issues/29775575-linux-nvme-h-has-been-renamed-in-linux-4-4
