### PR TITLE
Add nvme support for scan

### DIFF
--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -38,7 +38,7 @@ int diskScan()
 	printf("\nScanning for Opal compliant disks\n");
 	while (TRUE) {
 		DEVICEMASK;
-		//snprintf(devname,23,"/dev/sd%c",(char) 0x61+i) Linux
+		//snprintf(devname,23,"/dev/sd%c",'a'+i) Linux
 		//sprintf_s(devname, 23, "\\\\.\\PhysicalDrive%i", i)  Windows
 		d = new DtaDevGeneric(devname);
 		if (d->isPresent()) {

--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -35,7 +35,11 @@ uint8_t UnlockSEDs(char * password) {
     LOG(D4) << "Enter UnlockSEDs";
     mvprintw(6,2,"Scanning....");
     while (TRUE) {
-        snprintf(devref,23,"/dev/sd%c",(char) 0x61+i);
+        switch(DtaDevOS::getNextDevice(i)){
+            case 1  : snprintf(devref,23,"/dev/%s",DtaDevOS::getDeviceName()); break;
+            case -1 : snprintf(devref,23,"/dev/sd%c",(char) 0x61+i);    break;
+            default : snprintf(devref,23,"/dev/sdX"); break;
+        }
          i += 1;
 	tempDev = new DtaDevGeneric(devref);
 	if (!tempDev->isPresent()) {break;}
@@ -64,7 +68,7 @@ uint8_t UnlockSEDs(char * password) {
             failed = 1;
         }
         printw("%s",(failed ? "Failed" : "Success"));
-    delete d;             
+    delete d;
     doupdate();
     if (MAX_DISKS == i) {
         LOG(I) << MAX_DISKS << " disks, really?";

--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -37,7 +37,7 @@ uint8_t UnlockSEDs(char * password) {
     while (TRUE) {
         switch(DtaDevOS::getNextDevice(i)){
             case 1  : snprintf(devref,23,"/dev/%s",DtaDevOS::getDeviceName()); break;
-            case -1 : snprintf(devref,23,"/dev/sd%c",(char) 0x61+i);    break;
+            case -1 : snprintf(devref,23,"/dev/sd%c",(char) 0xa+i);    break;
             default : snprintf(devref,23,"/dev/sdX"); break;
         }
          i += 1;

--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -37,7 +37,7 @@ uint8_t UnlockSEDs(char * password) {
     while (TRUE) {
         switch(DtaDevOS::getNextDevice(i)){
             case 1  : snprintf(devref,23,"/dev/%s",DtaDevOS::getDeviceName()); break;
-            case -1 : snprintf(devref,23,"/dev/sd%c",(char) 0xa+i);    break;
+            case -1 : snprintf(devref,23,"/dev/sd%c",'a'+i);    break;
             default : snprintf(devref,23,"/dev/sdX"); break;
         }
          i += 1;

--- a/LinuxPBA/nbproject/Makefile-Debug.mk
+++ b/LinuxPBA/nbproject/Makefile-Debug.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=i686-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=i686-linux-ranlib
+CC=i686-linux-gcc
+CCC=i686-linux-g++
+CXX=i686-linux-g++
+FC=i686-linux-gfortran
+AS=i686-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux
@@ -72,7 +72,7 @@ FFLAGS=
 ASFLAGS=
 
 # Link Libraries and Options
-LDLIBSOPTIONS=-lcurses
+LDLIBSOPTIONS=-lcurses -ltinfo
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}

--- a/LinuxPBA/nbproject/Makefile-Debug_x86_64.mk
+++ b/LinuxPBA/nbproject/Makefile-Debug_x86_64.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=x86_64-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=x86_64-linux-ranlib
+CC=x86_64-linux-gcc
+CCC=x86_64-linux-g++
+CXX=x86_64-linux-g++
+FC=x86_64-linux-gfortran
+AS=x86_64-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux
@@ -72,7 +72,7 @@ FFLAGS=
 ASFLAGS=
 
 # Link Libraries and Options
-LDLIBSOPTIONS=-lcurses
+LDLIBSOPTIONS=-lcurses -ltinfo
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}

--- a/LinuxPBA/nbproject/Makefile-Release.mk
+++ b/LinuxPBA/nbproject/Makefile-Release.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=i686-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=i686-linux-ranlib
+CC=i686-linux-gcc
+CCC=i686-linux-g++
+CXX=i686-linux-g++
+FC=i686-linux-gfortran
+AS=i686-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux
@@ -72,7 +72,7 @@ FFLAGS=
 ASFLAGS=
 
 # Link Libraries and Options
-LDLIBSOPTIONS=-lcurses
+LDLIBSOPTIONS=-lcurses -ltinfo
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}

--- a/LinuxPBA/nbproject/Makefile-Release_x86_64.mk
+++ b/LinuxPBA/nbproject/Makefile-Release_x86_64.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=x86_64-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=x86_64-linux-ranlib
+CC=x86_64-linux-gcc
+CCC=x86_64-linux-g++
+CXX=x86_64-linux-g++
+FC=x86_64-linux-gfortran
+AS=x86_64-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux
@@ -72,7 +72,7 @@ FFLAGS=
 ASFLAGS=
 
 # Link Libraries and Options
-LDLIBSOPTIONS=-lcurses
+LDLIBSOPTIONS=-lcurses -ltinfo
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}

--- a/images/.dockerignore
+++ b/images/.dockerignore
@@ -1,0 +1,1 @@
+scratch

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386 && apt update && apt install -y \
+        bc \
+        build-essential \
+        cpio \
+        dosfstools \
+        g++-multilib \
+        gdisk \
+        git-core \
+        libncurses5-dev \
+        libncurses5-dev:i386 \
+        python \
+        squashfs-tools \
+        sudo \
+        unzip \
+        wget \
+        locales \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/sedutil"
+
+CMD "/sedutil/images/autobuild.sh"

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,23 @@
+# Images
+
+## Docker
+
+Docker can be used as a repeatable build environment to build the images in an Ubuntu 16.04 container.  Steps to reproduce from the `images` directory:
+
+
+### Step 1 - Build the Docker container
+
+    docker build -t sedutil .
+
+### Step 2 - Run the build from within the Docker container
+
+Try the `autobuild.sh` script which runs automatically when no command is
+passed:
+
+    docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil
+
+Or, refer to `BUILDING` file and run manually in the Docker container by
+starting `bash`:
+
+    docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil bash
+

--- a/images/autobuild.sh
+++ b/images/autobuild.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Echo commands and abort on error
+set -ex
+
+# Optimal MAKEFLAGS argument if not already defined
+if [ -z ${MAKEFLAGS+x} ]; then
+    # Add 1 assuming disk IO will block processes from time to time.
+    export MAKEFLAGS=$((1 + $(grep processor /proc/cpuinfo | wc -l)))
+fi
+
+# Run everything from the path of this script despite how invoked
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+source conf
+
+# Build buildroot before other tools as it provides the toolchain for linuxpba
+# and sedutil-cli.
+./getresources
+./buildpbaroot
+
+pushd ../LinuxPBA
+rm -rf dist build
+make CONF=Debug
+make CONF=Debug_x86_64
+make CONF=Release
+make CONF=Release_x86_64
+popd
+
+pushd ../linux/CLI
+rm -rf dist build
+make CONF=Debug_i686
+make CONF=Debug_x86_64
+make CONF=Release_i686
+make CONF=Release_x86_64
+popd
+
+# Build BIOS images (untested, probably subtly broken)
+#./buildbiospba Release
+#./buildbiospba Debug
+
+# Build UEFI images
+./buildUEFI64 Release
+./buildUEFI64 Debug
+
+# Rescue build
+./buildrescue

--- a/images/buildUEFI64
+++ b/images/buildUEFI64
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 # Build a custom UEFI linux based PBA image
 ## define releases for tools
 . conf
@@ -23,7 +23,7 @@ fi
       -f buildroot/syslinux.cfg \
   ] || { echo " prereqs are not available "; exit 1; }
 # recreate the initrd file with the latest PBA
-mkdir scratch/buildroot/PBA64/overlay/sbin/
+mkdir -p scratch/buildroot/PBA64/overlay/sbin/
 cp ../LinuxPBA/dist/${BUILDTYPE}_x86_64/GNU-Linux/linuxpba  scratch/buildroot/PBA64/overlay/sbin/linuxpba
 cp ../linux/CLI/dist/${BUILDTYPE}_x86_64/GNU-Linux/sedutil-cli  scratch/buildroot/PBA64/overlay/sbin/sedutil-cli
 cd scratch/buildroot

--- a/images/buildpbaroot
+++ b/images/buildpbaroot
@@ -1,5 +1,5 @@
 #!/bin/bash
-set +x
+set -ex
 function die {
 echo An error has occured please fix this and start over
 exit 99
@@ -20,17 +20,15 @@ cp ../../buildroot/ncurses.mk package/ncurses/
 # 64 bit system
 mkdir PBA64
 cp ../../buildroot/PBA64/.config PBA64/
-cp ../../buildroot/PBA64/* PBA64/
-cp -r ../../buildroot/PBA64/overlay PBA64/
+cp -r ../../buildroot/PBA64/* PBA64/
 
 # 32 bit system
 mkdir PBA32
 cp ../../buildroot/PBA32/.config PBA32/
-cp ../../buildroot/PBA32/* PBA32/
-cp -r ../../buildroot/PBA32/overlay PBA32/
+cp -r ../../buildroot/PBA32/* PBA32/
 
-echo This is going to take a while ..... Press enter to continue
-read INOUT
+#echo This is going to take a while ..... Press enter to continue
+#read INOUT
 echo Making the 64bit PBA Linux system
 make O=PBA64 2>&1 | tee PBA64/build_output.txt
 echo Making the 32bit PBA Linux system

--- a/images/buildrescue
+++ b/images/buildrescue
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 # Build a custom tinycore bootable image
 ## define releases for tools
 . conf
@@ -18,7 +18,7 @@ sudo rm -rf ${BUILDTYPE} ; mkdir ${BUILDTYPE} ; cd ${BUILDTYPE}
      -f ${PROGRAM} \
   ] || { echo " prereqs are not available "; exit 1; }
 #
-dd if=/dev/zero of=${BUILDIMG} bs=1M count=15
+dd if=/dev/zero of=${BUILDIMG} bs=1M count=30
 (echo o;echo n;echo p;echo 1;echo "";echo "";echo a;echo 1;echo w) | fdisk -C 100 ${BUILDIMG}
 dd if=../scratch/${SYSLINUX}/bios/mbr/mbr.bin of=${BUILDIMG} count=1 conv=notrunc bs=512
 LOOPDEV=`sudo losetup --show -f -o 1048576 ${BUILDIMG}`
@@ -44,6 +44,9 @@ cd ..
 sudo mkdir -p core/usr/local/sbin/
 sudo unsquashfs -f -li -d core ../scratch/hdparm.tcz
 sudo cp ${PROGRAM} core/usr/local/sbin/
+## Bundle UEFI images
+sudo gunzip -k /sedutil/images/UEFI*/*.gz
+sudo cp /sedutil/images/UEFI*/*.img core/
 ## now repackage it
 cd core
 sudo find | sudo cpio -o -H newc | gzip -9 > ../image/boot/core.gz

--- a/images/buildroot/PBA32/kernel.config
+++ b/images/buildroot/PBA32/kernel.config
@@ -711,7 +711,7 @@ CONFIG_BLK_DEV_LOOP_MIN_COUNT=8
 #
 # DRBD disabled because PROC_FS or INET not selected
 #
-# CONFIG_BLK_DEV_NVME is not set
+CONFIG_BLK_DEV_NVME=y
 # CONFIG_BLK_DEV_SKD is not set
 # CONFIG_BLK_DEV_SX8 is not set
 # CONFIG_BLK_DEV_RAM is not set

--- a/images/buildroot/PBA64/kernel.config
+++ b/images/buildroot/PBA64/kernel.config
@@ -726,7 +726,7 @@ CONFIG_BLK_DEV_LOOP_MIN_COUNT=8
 #
 # DRBD disabled because PROC_FS or INET not selected
 #
-# CONFIG_BLK_DEV_NVME is not set
+CONFIG_BLK_DEV_NVME=y
 # CONFIG_BLK_DEV_SKD is not set
 # CONFIG_BLK_DEV_SX8 is not set
 # CONFIG_BLK_DEV_RAM is not set

--- a/images/conf
+++ b/images/conf
@@ -6,3 +6,15 @@ SYSLINUX=syslinux-6.03
 TCDISTRO=http://distro.ibiblio.org/tinycorelinux/6.x/x86/
 BUILDROOT=git://git.buildroot.net/buildroot
 BUILDROOT_TAG=2015.11
+
+# Prefix PATH with i686 toolchain path, only once
+PATH_TC_32="/sedutil/images/scratch/buildroot/PBA32/host/usr/bin"
+if [[ $PATH != ${PATH_TC_32}* ]]; then
+    export PATH="$PATH_TC_32:$PATH"
+fi
+
+# Prefix PATH with x86_64 toolchain path, only once
+PATH_TC_64="/sedutil/images/scratch/buildroot/PBA64/host/usr/bin"
+if [[ $PATH != ${PATH_TC_64}* ]]; then
+    export PATH="$PATH_TC_64:$PATH"
+fi

--- a/images/docker-build
+++ b/images/docker-build
@@ -1,0 +1,2 @@
+docker build -t sedutil .
+docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil $@

--- a/images/getresources
+++ b/images/getresources
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 ## Get version information
 . conf
 ## Make a clean start

--- a/linux/CLI/nbproject/Makefile-Debug_i686.mk
+++ b/linux/CLI/nbproject/Makefile-Debug_i686.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=i686-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=i686-linux-ranlib
+CC=i686-linux-gcc
+CCC=i686-linux-g++
+CXX=i686-linux-g++
+FC=i686-linux-gfortran
+AS=i686-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux

--- a/linux/CLI/nbproject/Makefile-Debug_x86_64.mk
+++ b/linux/CLI/nbproject/Makefile-Debug_x86_64.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=x86_64-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=x86_64-linux-ranlib
+CC=x86_64-linux-gcc
+CCC=x86_64-linux-g++
+CXX=x86_64-linux-g++
+FC=x86_64-linux-gfortran
+AS=x86_64-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux

--- a/linux/CLI/nbproject/Makefile-Release_i686.mk
+++ b/linux/CLI/nbproject/Makefile-Release_i686.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=i686-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=i686-linux-ranlib
+CC=i686-linux-gcc
+CCC=i686-linux-g++
+CXX=i686-linux-g++
+FC=i686-linux-gfortran
+AS=i686-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux

--- a/linux/CLI/nbproject/Makefile-Release_x86_64.mk
+++ b/linux/CLI/nbproject/Makefile-Release_x86_64.mk
@@ -11,14 +11,14 @@
 MKDIR=mkdir
 CP=cp
 GREP=grep
-NM=nm
+NM=x86_64-linux-nm
 CCADMIN=CCadmin
-RANLIB=ranlib
-CC=gcc
-CCC=g++
-CXX=g++
-FC=gfortran
-AS=as
+RANLIB=x86_64-linux-ranlib
+CC=x86_64-linux-gcc
+CCC=x86_64-linux-g++
+CXX=x86_64-linux-g++
+FC=x86_64-linux-gfortran
+AS=x86_64-linux-as
 
 # Macros
 CND_PLATFORM=GNU-Linux

--- a/linux/DtaDevLinuxNvme.h
+++ b/linux/DtaDevLinuxNvme.h
@@ -18,7 +18,13 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
-#include "linux/nvme.h"
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#include <linux/nvme_ioctl.h>
+#include "DtaDevLinuxNvmeStructsOpCodes.h"
+#else
+#include <linux/nvme.h>
+#endif
 #include "DtaStructures.h"
 #include "DtaDevLinuxDrive.h"
 

--- a/linux/DtaDevLinuxNvmeStructsOpCodes.h
+++ b/linux/DtaDevLinuxNvmeStructsOpCodes.h
@@ -1,0 +1,95 @@
+/*
+ * Definitions for the NVM Express interface
+ * Copyright (c) 2011-2014, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#pragma once
+
+enum nvme_admin_opcode {
+        nvme_admin_delete_sq            = 0x00,
+        nvme_admin_create_sq            = 0x01,
+        nvme_admin_get_log_page         = 0x02,
+        nvme_admin_delete_cq            = 0x04,
+        nvme_admin_create_cq            = 0x05,
+        nvme_admin_identify             = 0x06,
+        nvme_admin_abort_cmd            = 0x08,
+        nvme_admin_set_features         = 0x09,
+        nvme_admin_get_features         = 0x0a,
+        nvme_admin_async_event          = 0x0c,
+        nvme_admin_activate_fw          = 0x10,
+        nvme_admin_download_fw          = 0x11,
+        nvme_admin_format_nvm           = 0x80,
+        nvme_admin_security_send        = 0x81,
+        nvme_admin_security_recv        = 0x82,
+};
+
+struct nvme_id_power_state {
+        __le16                  max_power;      /* centiwatts */
+        __u8                    rsvd2;
+        __u8                    flags;
+        __le32                  entry_lat;      /* microseconds */
+        __le32                  exit_lat;       /* microseconds */
+        __u8                    read_tput;
+        __u8                    read_lat;
+        __u8                    write_tput;
+        __u8                    write_lat;
+        __le16                  idle_power;
+        __u8                    idle_scale;
+        __u8                    rsvd19;
+        __le16                  active_power;
+        __u8                    active_work_scale;
+        __u8                    rsvd23[9];
+};
+
+struct nvme_id_ctrl {
+        __le16                  vid;
+        __le16                  ssvid;
+        char                    sn[20];
+        char                    mn[40];
+        char                    fr[8];
+        __u8                    rab;
+        __u8                    ieee[3];
+        __u8                    mic;
+        __u8                    mdts;
+        __le16                  cntlid;
+        __le32                  ver;
+        __u8                    rsvd84[172];
+        __le16                  oacs;
+        __u8                    acl;
+        __u8                    aerl;
+        __u8                    frmw;
+        __u8                    lpa;
+        __u8                    elpe;
+        __u8                    npss;
+        __u8                    avscc;
+        __u8                    apsta;
+        __le16                  wctemp;
+        __le16                  cctemp;
+        __u8                    rsvd270[242];
+        __u8                    sqes;
+        __u8                    cqes;
+        __u8                    rsvd514[2];
+        __le32                  nn;
+        __le16                  oncs;
+        __le16                  fuses;
+        __u8                    fna;
+        __u8                    vwc;
+        __le16                  awun;
+        __le16                  awupf;
+        __u8                    nvscc;
+        __u8                    rsvd531;
+        __le16                  acwu;
+        __u8                    rsvd534[2];
+        __le32                  sgls;
+        __u8                    rsvd540[1508];
+        struct nvme_id_power_state      psd[32];
+        __u8                    vs[1024];
+};

--- a/linux/DtaDevOS.h
+++ b/linux/DtaDevOS.h
@@ -20,6 +20,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 #include "DtaDev.h"
 #include "DtaDevLinuxDrive.h"
+#include <dirent.h>
 
 /** Linux specific implementation of DtaDevOS.
  */
@@ -47,6 +48,9 @@ public:
      */
     uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
             void * buffer, uint16_t bufferlen);
+
+    static char * getDeviceName();
+    static int getNextDevice(int i);
 protected:
     /** OS specific command to Wait for specified number of milliseconds 
      * @param ms  number of milliseconds to wait

--- a/linux/os.h
+++ b/linux/os.h
@@ -32,5 +32,9 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 // a few OS specific methods that need to be worked out
 #define SNPRINTF snprintf
 // Cumbersome, but trying to avoid editing common files. If /sys/block is not present, reverts to enumerating /dev/sd* devices. 
-#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)){ case 1  : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); break; case -1 : snprintf(devname,23,"/dev/sd%c",(char) 0x61+i); break; default : snprintf(devname,23,"/dev/sdX"); break; }
+#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)){ \
+    case 1  : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); break; \
+    case -1 : snprintf(devname,23,"/dev/sd%c",(char) 0xa+i); break; \
+    default : snprintf(devname,23,"/dev/sdX"); break; \
+}
 #define DEVICEEXAMPLE "/dev/sdc"

--- a/linux/os.h
+++ b/linux/os.h
@@ -32,9 +32,12 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 // a few OS specific methods that need to be worked out
 #define SNPRINTF snprintf
 // Cumbersome, but trying to avoid editing common files. If /sys/block is not present, reverts to enumerating /dev/sd* devices. 
-#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)){ \
-    case 1  : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); break; \
-    case -1 : snprintf(devname,23,"/dev/sd%c",(char) 0xa+i); break; \
-    default : snprintf(devname,23,"/dev/sdX"); break; \
+#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)) {
+    case 1 : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); 
+        break;
+    case -1 : snprintf(devname,23,"/dev/sd%c",'a'+i); 
+        break;
+    default : snprintf(devname,23,"/dev/sdX"); 
+        break;
 }
 #define DEVICEEXAMPLE "/dev/sdc"

--- a/linux/os.h
+++ b/linux/os.h
@@ -31,5 +31,6 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #define FALSE 0
 // a few OS specific methods that need to be worked out
 #define SNPRINTF snprintf
-#define DEVICEMASK snprintf(devname,23,"/dev/sd%c",(char) 0x61+i)
+// Cumbersome, but trying to avoid editing common files. If /sys/block is not present, reverts to enumerating /dev/sd* devices. 
+#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)){ case 1  : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); break; case -1 : snprintf(devname,23,"/dev/sd%c",(char) 0x61+i); break; default : snprintf(devname,23,"/dev/sdX"); break; }
 #define DEVICEEXAMPLE "/dev/sdc"

--- a/linux/os.h
+++ b/linux/os.h
@@ -32,12 +32,9 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 // a few OS specific methods that need to be worked out
 #define SNPRINTF snprintf
 // Cumbersome, but trying to avoid editing common files. If /sys/block is not present, reverts to enumerating /dev/sd* devices. 
-#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)) {
-    case 1 : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); 
-        break;
-    case -1 : snprintf(devname,23,"/dev/sd%c",'a'+i); 
-        break;
-    default : snprintf(devname,23,"/dev/sdX"); 
-        break;
+#define DEVICEMASK switch(DtaDevOS::getNextDevice(i)) { \
+    case 1 : snprintf(devname,23,"/dev/%s",DtaDevOS::getDeviceName()); break; \
+    case -1 : snprintf(devname,23,"/dev/sd%c",'a'+i); break; \
+    default : snprintf(devname,23,"/dev/sdX"); break; \ 
 }
 #define DEVICEEXAMPLE "/dev/sdc"


### PR DESCRIPTION
Created method in DevOS that finds block devices in /sys/block matching patterns /dev/sd* and /dev/nvme*. This approach should be more robust, since it will find also find drives that are not consecutive (i.e. /dev/sda and /dev/sdc, skipping /dev/sdb).