### PR TITLE
Fix compile errors on kernels with backported linux/nvme_ioctl.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PROG_CC
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h malloc.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h])
+AC_CHECK_HEADERS([linux/nvme.h linux/nvme_ioctl.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/linux/DtaDevLinuxNvme.h
+++ b/linux/DtaDevLinuxNvme.h
@@ -18,8 +18,9 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
+#include "config.h"
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#ifdef HAVE_LINUX_NVME_IOCTL_H
 #include <linux/nvme_ioctl.h>
 #else
 #include <linux/nvme.h>


### PR DESCRIPTION
This change fixes compile errors on CentOS 7, RHEL 7, and other distributions have have back ported the nvme_ioctl.h change.  Instead of checking the kernel version this change checks for the existence of the nvme include file with autoconf.