### PR TITLE
Fixes issue #200: scaning does not work with SAS (TCG/Enterprise) drives.

### DIFF
--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -271,6 +271,9 @@ void DtaDevLinuxSata::identify(OPAL_DiskInfo& disk_info)
 
     if (!(memcmp(nullz.data(), buffer, 512))) {
         disk_info.devType = DEVICE_TYPE_OTHER;
+        // XXX: ioctl call was aborted or returned no data, most probably
+        //      due to driver not being libata based, let's try SAS instead.
+        identify_SAS(&disk_info);
         return;
     }
     IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;


### PR DESCRIPTION
This is a oneliner fix ensuring SAT-2 passthru drive identification logic attempts, when failing, are retried as SCSI inquiry commands, in order to correctly detect enterprise SAS drives.

See: https://github.com/Drive-Trust-Alliance/sedutil/issues/200