### PR TITLE
Fix verbose (-vvv..) command line arguments.

### DIFF
--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -126,6 +126,7 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
 			loggingLevel += (uint16_t)(strlen(argv[i]) - 1);
 			if (loggingLevel > 7) loggingLevel = 7;
 			CLog::Level() = CLog::FromInt(loggingLevel);
+			RCLog::Level() = RCLog::FromInt(loggingLevel);
 			LOG(D) << "Log level set to " << CLog::ToString(CLog::FromInt(loggingLevel));
 			LOG(D) << "sedutil version : " << GIT_VERSION;
 		}


### PR DESCRIPTION
Passing -vvvv arguments to sedutil make no difference due to it only enabling CLog logging (which seems currently being replaced by the alternate RCLog class/code), so this pull-req wires verbose option to RCLog::Level() in addition to CLog::Level().
