### PR TITLE
Support HGST SSD400M SAS drives

### DIFF
--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -271,6 +271,9 @@ void DtaDevLinuxSata::identify(OPAL_DiskInfo& disk_info)
 
     if (!(memcmp(nullz.data(), buffer, 512))) {
         disk_info.devType = DEVICE_TYPE_OTHER;
+        // XXX: ioctl call was aborted or returned no data, most probably
+        //      due to driver not being libata based, let's try SAS instead.
+        identify_SAS(&disk_info);
         return;
     }
     IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;


### PR DESCRIPTION
Hi,

While working with the aforementioned SAS/SSD drives I've found the length field reported by the drive to a discovery0 request to be incorrect. Instead of reporting the full length of the discovery0 header + feature pages. It only reports the space occupied by feature pages (assuming the discovery0 header size is fixed and can be accounted on it's own, I guess).

This patch, overcomes such issue, by assuming a length field smaller than the discovery0 header size, should not be accounting for the header. So we keep parsing discovery0 response by as much as such length bytes of feature pages.