### PR TITLE
Correcting allow_tpm w.r.t NVMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ standard on bios machines.
 
 You must be administrator/root to run the host managment program
 
-In Linux libata.allow_tpm must be set to 1. Either via adding libata.allow_tpm=1 to the kernel flags at boot time 
-or changing the contents of /sys/module/libata/parameters/allow_tpm from a "0" to a "1" on a running system.
+In Linux libata.allow_tpm must be set to 1 for SATA-based drives,
+including NGFF/M.2 SATA drives.Either adding libata.allow_tpm=1
+to the kernel flags at boot time or changing the contents of
+/sys/module/libata/parameters/allow_tpm from a "0" to a "1" on
+a running system if possible will accomplish this. NVMe drives
+do not need this parameter.
 
 ***** sleep (S3) is not supported.
 


### PR DESCRIPTION
NVMe drives don't need or even interact with libata (and in fact a fully working kernel for many modern laptops can be built without libata even enabled).

Also cleaning up formatting in-file of the markdown for this paragraph while I'm editing it.