### PR TITLE
Common/log.h: time(2) needs <time.h>

### DIFF
--- a/Common/log.h
+++ b/Common/log.h
@@ -341,6 +341,7 @@ inline std::string NowTime() {
 
 #else
 
+#include <time.h>
 #include <sys/time.h>
 
 inline std::string NowTime() {


### PR DESCRIPTION
Otherwise the build fails with:

In file included from ./linux/os.h:28:0,
                 from Common/DtaOptions.cpp:20:
./Common/log.h: In function ‘std::__cxx11::string NowTime()’:
./Common/log.h:349:12: error: ‘time’ was not declared in this scope
     time(&t);

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>