### PR TITLE
Add implementation of SecureString and SecureByteVector to stor…

### DIFF
--- a/Common/DtaCommand.cpp
+++ b/Common/DtaCommand.cpp
@@ -115,9 +115,18 @@ DtaCommand::addToken(uint64_t number)
 }
 
 void
-DtaCommand::addToken(vector<uint8_t> token)
+DtaCommand::addToken(const vector<uint8_t>& token)
 {
     LOG(D1) << "Entering addToken(vector<uint8_t>)";
+    for (uint32_t i = 0; i < token.size(); i++) {
+        cmdbuf[bufferpos++] = token[i];
+    }
+}
+
+void
+DtaCommand::addToken(const SecureByteVector& token)
+{
+    LOG(D1) << "Entering addToken(vector<SecureByteVector>)";
     for (uint32_t i = 0; i < token.size(); i++) {
         cmdbuf[bufferpos++] = token[i];
     }

--- a/Common/DtaCommand.h
+++ b/Common/DtaCommand.h
@@ -21,6 +21,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <vector>
 #include "DtaLexicon.h"
+#include "SecureContainer.h"
 class DtaDevOpal;
 class DtaDevEnterprise;
 
@@ -62,7 +63,8 @@ public:
     /** Add a Token to the bytstream of type vector<uint8_t>.
      * This token must be a complete token properly encoded
      * with the proper TCG bytestream header information  */
-    void addToken(std::vector<uint8_t> token);
+    void addToken(const vector<uint8_t>& token);
+    void addToken(const SecureByteVector& token);
     /** Add a Token to the bytstream of type uint64. */
     void addToken(uint64_t number);
     /** Set the commid to be used in the command. */

--- a/Common/DtaDevEnterprise.h
+++ b/Common/DtaDevEnterprise.h
@@ -88,8 +88,8 @@ public:
          * @param name the column name to be set
          * @param value data to be stored the the column 
          */
-	uint8_t setTable(vector<uint8_t> table, const char *name,
-		vector<uint8_t> value);
+	template<class T> uint8_t setTable(vector<uint8_t> table, const char *name,
+		const T& value);
         /** set a single column in a table 
          * @param table the UID of the table
          * @param name the column name to be set

--- a/Common/DtaDevOpal.h
+++ b/Common/DtaDevOpal.h
@@ -86,14 +86,14 @@ public:
          * @param name the column name to be set
          * @param value data to be stored the the column 
          */
-	uint8_t setTable(vector<uint8_t> table, OPAL_TOKEN name,
-		vector<uint8_t> value);
+	template<class T> uint8_t setTable(const vector<uint8_t>& table, OPAL_TOKEN name,
+		const T& value);
          /** set a single column in an object table 
          * @param table the UID of the table
          * @param name the column name to be set
          * @param value data to be stored the the column 
          */
-	uint8_t setTable(vector<uint8_t> table, OPAL_TOKEN name,
+	uint8_t setTable(const vector<uint8_t>& table, OPAL_TOKEN name,
 		OPAL_TOKEN value);
         /** Change state of the Locking SP to active.
          * Enables locking 
@@ -288,5 +288,4 @@ protected:
 	 *  @param password Admin1 Password for TPer
 	 */
 	lrStatus_t getLockingRange_status(uint8_t lockingrange, char * password);
-
 };

--- a/Common/DtaHashPwd.h
+++ b/Common/DtaHashPwd.h
@@ -18,6 +18,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
+#include "SecureContainer.h"
 #include <vector>
 class DtaDev;
 
@@ -32,7 +33,7 @@ using namespace std;
  * @param password The password to be hashed
  * @param device the device where the password is to be used
  */
-void DtaHashPwd(vector<uint8_t> &hash, char * password, DtaDev * device);
+void DtaHashPwd(std::shared_ptr<SecureByteVector> &hash, char * password, DtaDev * device);
 /** Hash a passwor using the PBDKF2<SHA1> function 
  *
  * @param hash Field where hash returned
@@ -41,7 +42,7 @@ void DtaHashPwd(vector<uint8_t> &hash, char * password, DtaDev * device);
  * @param iter number of iterations to be preformed 
  * @param hashsize size of hash to be returned
  */
-void DtaHashPassword(vector<uint8_t> &hash, char * password, vector<uint8_t> salt,
+void DtaHashPassword(std::shared_ptr<SecureByteVector> &hash, char * password, vector<uint8_t> salt,
         unsigned int iter = 75000, uint8_t hashsize = 32);
 /** Test the hshing function using publicly available test cased and report */
 int TestPBKDF2();

--- a/Common/DtaSession.cpp
+++ b/Common/DtaSession.cpp
@@ -97,7 +97,7 @@ DtaSession::start(OPAL_UID SP, char * HostChallenge, vector<uint8_t> SignAuthori
 #endif
 {
     LOG(D1) << "Entering DtaSession::startSession ";
-	vector<uint8_t> hash;
+    std::shared_ptr<SecureByteVector> hash = std::allocate_shared<SecureByteVector>(SecureAllocator<SecureByteVector>(), 0);
 	lastRC = 0;
 
     DtaCommand *cmd = new DtaCommand();
@@ -115,9 +115,9 @@ DtaSession::start(OPAL_UID SP, char * HostChallenge, vector<uint8_t> SignAuthori
 		cmd->addToken(OPAL_TOKEN::STARTNAME);
 		cmd->addToken(OPAL_TINY_ATOM::UINT_00);
 		if (hashPwd) {
-			hash.clear();
+			hash->clear();
 			DtaHashPwd(hash, HostChallenge, d);
-			cmd->addToken(hash);
+			cmd->addToken(*hash);
 		} else {
 			cmd->addToken(HostChallenge);
 		}
@@ -159,7 +159,7 @@ uint8_t
 DtaSession::authenticate(vector<uint8_t> Authority, char * Challenge)
 {
 	LOG(D1) << "Entering DtaSession::authenticate ";
-	vector<uint8_t> hash;
+    std::shared_ptr<SecureByteVector> hash = std::allocate_shared<SecureByteVector>(SecureAllocator<SecureByteVector>(), 0);
 	DtaCommand *cmd = new DtaCommand();
 	if (NULL == cmd) {
 		LOG(E) << "Unable to create session object ";
@@ -177,9 +177,9 @@ DtaSession::authenticate(vector<uint8_t> Authority, char * Challenge)
 		else
 			cmd->addToken(OPAL_TINY_ATOM::UINT_00);
 		if (hashPwd) {
-			hash.clear();
+			hash->clear();
 			DtaHashPwd(hash, Challenge, d);
-			cmd->addToken(hash);
+			cmd->addToken(*hash);
 		}
 		else
 			cmd->addToken(Challenge);

--- a/Common/SecureContainer.h
+++ b/Common/SecureContainer.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <vector>
+#ifdef __linux__
+#include <memory>
+#include <sys/mman.h>
+
+/**
+  This allocator zeros the memory before deallocating
+  The memory allocated is locked into RAM, preventing that memory from being paged to the swap area
+  */
+template <class T> class SecureAllocator : public std::allocator<T>
+{
+    public:
+        template<class U> struct rebind { typedef SecureAllocator<U> other; };
+
+        SecureAllocator() throw() {}
+        SecureAllocator(const SecureAllocator&) throw() {}
+        template <class U> SecureAllocator(const SecureAllocator<U>&) throw() {}
+
+        typename std::allocator<T>::pointer allocate(typename std::allocator<T>::size_type n, std::allocator<void>::const_pointer hint=0)
+        {
+            typename std::allocator<T>::pointer p = std::allocator<T>::allocate(n, hint);
+            mlock(p, n*sizeof(T));
+            return p;
+        }
+
+        void deallocate(typename std::allocator<T>::pointer p, typename std::allocator<T>::size_type n)
+        {
+            std::fill_n((volatile char*)p, n*sizeof(T), 0);
+            munlock(p, n*sizeof(T));
+            std::allocator<T>::deallocate(p, n);
+        }
+};
+
+typedef std::basic_string<char, std::char_traits<char>, SecureAllocator<char>> SecureString;
+typedef std::vector<uint8_t, SecureAllocator<uint8_t>> SecureByteVector;
+#else
+#include <string>
+typedef std::string SecureString;
+typedef std::vector<uint8_t> SecureByteVector;
+#endif //__linux__

--- a/LinuxPBA/GetPassPhrase.cpp
+++ b/LinuxPBA/GetPassPhrase.cpp
@@ -20,7 +20,6 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "os.h"
 #include "GetPassPhrase.h"
-#include <string>
 #include <termios.h>
 #include <stdio.h>
 using namespace std;
@@ -58,11 +57,11 @@ char getch(void)
   return getch_(0);
 }
 
-string GetPassPhrase(const char *prompt, bool show_asterisk)
+std::shared_ptr<SecureString> GetPassPhrase(const char *prompt, bool show_asterisk)
 {
   const char BACKSPACE=127;
   const char RETURN=10;
-  string password;
+  std::shared_ptr<SecureString> password = std::allocate_shared<SecureString>(SecureAllocator<SecureString>(), "");
   unsigned char ch=0;
   LOG(D4) << "Enter GetPassPhrase" << endl;
   printf("\n\n%s",prompt);
@@ -71,16 +70,16 @@ string GetPassPhrase(const char *prompt, bool show_asterisk)
 //      LOG(I) << "key value" << (uint16_t) ch << endl;
        if(ch==BACKSPACE)
          {
-            if(password.length()!=0)
+            if(password->length()!=0)
               {
                  if(show_asterisk)
                  printf("\b \b");
-                 password.resize(password.length()-1);
+                 password->resize(password->length()-1);
               }
          }
        else if(ch!=27) // ignore 'escape' key
          {
-             password+=ch;
+             password->push_back(ch);
              if(show_asterisk)
                  printf("*");
          }

--- a/LinuxPBA/GetPassPhrase.h
+++ b/LinuxPBA/GetPassPhrase.h
@@ -18,6 +18,5 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
 * C:E********************************************************************** */
 #pragma once
-#include <string>
-using namespace std;
-string GetPassPhrase(const char *prompt, bool show_asterisk=true);
+#include "SecureContainer.h"
+std::shared_ptr<SecureString> GetPassPhrase(const char *prompt, bool show_asterisk=true);

--- a/LinuxPBA/LinuxPBA.cpp
+++ b/LinuxPBA/LinuxPBA.cpp
@@ -37,9 +37,9 @@ int main(int argc, char** argv) {
     LOG(D4) << "Legacy PBA start" << endl;
 //    system ("tput clear");
     printf("DTA LINUX Pre Boot Authorization \n");
-    string p = GetPassPhrase("Please enter pass-phrase to unlock OPAL drives: ");
-    UnlockSEDs((char *)p.c_str());
-    if (strcmp(p.c_str(), "debug")) {
+    std::shared_ptr<SecureString> p = GetPassPhrase("Please enter pass-phrase to unlock OPAL drives: ");
+    UnlockSEDs((char *)p->c_str());
+    if (strcmp(p->c_str(), "debug")) {
         printf("Starting OS \n");
         sync();
         reboot(RB_AUTOBOOT);

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ SEDUTIL_COMMON_CODE = \
 	Common/DtaStructures.h Common/log.h Common/DtaLexicon.h Common/DtaConstants.h Common/DtaEndianFixup.h \
 	Common/pbkdf2/blockwise.c Common/pbkdf2/blockwise.h Common/pbkdf2/chash.c Common/pbkdf2/chash.h Common/pbkdf2/handy.h \
 	Common/pbkdf2/hmac.c Common/pbkdf2/hmac.h Common/pbkdf2/pbkdf2.c Common/pbkdf2/pbkdf2.h Common/pbkdf2/sha1.c \
-	Common/pbkdf2/sha1.h Common/pbkdf2/tassert.h Common/pbkdf2/bitops.h
+	Common/pbkdf2/sha1.h Common/pbkdf2/tassert.h Common/pbkdf2/bitops.h Common/SecureContainer.h
 sbin_PROGRAMS = sedutil-cli linuxpba
 sedutil_cli_SOURCES = linux/Version.h Common/sedutil.cpp Common/DtaOptions.cpp Common/DtaOptions.h \
 	\


### PR DESCRIPTION
As suggested by this issue https://github.com/sedutil/sedutil/issues/14, this patch implements a secure container to store passphrases and any derivatives. The memory is zeroed at deallocation. 

This feature is not implemented for Windows because I was not able to compile and test it on this platform.