### PR TITLE
Quality-of-life and typo fixes in several files.

### DIFF
--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -84,12 +84,12 @@ uint8_t UnlockSEDs(char * password) {
             if (d->setLockingRange(0, OPAL_LOCKINGSTATE::READWRITE, password)) {
                 failed = 1;
             }
-            failed ? printf("Drive %-10s %-40s is OPAL Failed  \n", devref, d->getModelNum()) :
-                    printf("Drive %-10s %-40s is OPAL Unlocked   \n", devref, d->getModelNum());
+            failed ? printf("Drive %-10s %-40s is OPAL \033[1;31m Failed \033[0m \n", devref, d->getModelNum()) :
+                    printf("Drive %-10s %-40s is OPAL \033[1;32m Unlocked \033[0m \n", devref, d->getModelNum());
             delete d;
         }
         else {
-            printf("Drive %-10s %-40s is OPAL NOT LOCKED   \n", devref, d->getModelNum());
+            printf("Drive %-10s %-40s is OPAL \033[1;32m NOT LOCKED \033[0m \n", devref, d->getModelNum());
             delete d;
         }
 

--- a/images/buildpbaroot
+++ b/images/buildpbaroot
@@ -33,17 +33,13 @@ sed -i '/menu "System tools"/a \\tsource "package/sedutil/Config.in"' package/Co
 cp -r ../../buildroot/packages/sedutil/ package/
 # Make a distribution from the current source
 cd ../../..
-# Added -i 2019-10-03 based on lukefor tree
-autoreconf -i 
+autoreconf 
 ./configure
 make dist
 mkdir images/scratch/buildroot/dl/
 cp sedutil-*.tar.gz images/scratch/buildroot/dl/
 make distclean
-cd images/scratch/buildroot/dl
-tar xvfz sedutil-*.tar.gz
-mv sedutil sedutil-local
-cd ..
+cd images/scratch/buildroot
 # build the rootfs for 64 and 32 bit systems
 #echo Building bootable systems for the PBA, this is going to take a while ..... Press enter to continue
 #read INOUT

--- a/images/buildpbaroot
+++ b/images/buildpbaroot
@@ -1,19 +1,22 @@
 #!/bin/bash
 set -x
+#### Should probably use this function against some of the calls below....
 function die {
-echo An error has occured please fix this and start over
+echo An error has occurred!  Please fix this and start over!
 exit 99
 }
-. conf
+#. conf
 cd scratch
-# clean up and start over
-rm -rf buildroot
-git clone ${BUILDROOT} || die
+#### MOVED this section to ./getresources script since it was getting resources.
+#### clean up and start over
+#rm -rf buildroot
+#git clone ${BUILDROOT} || die
 cd buildroot
-git checkout -b PBABUILD ${BUILDROOT_TAG}  || die
-git reset --hard
-git clean -df
-# add out of tree build directoried and files
+#git checkout -b PBABUILD ${BUILDROOT_TAG}  || die
+#git reset --hard
+#git clean -df
+
+# add out of tree build directories and files
 # 64 bit system
 mkdir 64bit
 cp ../../buildroot/64bit/.config 64bit/
@@ -30,16 +33,22 @@ sed -i '/menu "System tools"/a \\tsource "package/sedutil/Config.in"' package/Co
 cp -r ../../buildroot/packages/sedutil/ package/
 # Make a distribution from the current source
 cd ../../..
-autoreconf 
+# Added -i 2019-10-03 based on lukefor tree
+autoreconf -i 
 ./configure
 make dist
 mkdir images/scratch/buildroot/dl/
 cp sedutil-*.tar.gz images/scratch/buildroot/dl/
 make distclean
-cd images/scratch/buildroot
+cd images/scratch/buildroot/dl
+tar xvfz sedutil-*.tar.gz
+mv sedutil sedutil-local
+cd ..
 # build the rootfs for 64 and 32 bit systems
-echo Building bootable systems for the PBA, this is going to take a while ..... Press enter to continue
-read INOUT
+#echo Building bootable systems for the PBA, this is going to take a while ..... Press enter to continue
+#read INOUT
+# Don't stop in the middle of a build to chat....
+echo Building bootable systems for the PBA, this is going to take a while ...
 echo Making the 64bit PBA Linux system
 make O=64bit 2>&1 | tee 64bit/build_output.txt
 echo Making the 32bit PBA Linux system

--- a/images/buildrescue
+++ b/images/buildrescue
@@ -13,7 +13,7 @@ elif [ x${1} == "xRescue64" ] ; then
 	BUILDTYPE="RESCUE64"
 	ROOTDIR="64bit"
 else 
-	echo "NO BUILDTYPE specified defalted to Rescue32"
+	echo "NO BUILDTYPE specified; defaulted to Rescue32"
 fi
 BUILDIMG=${BUILDTYPE}-${VERSIONINFO}.img
 echo "Building " $BUILDTYPE "image"

--- a/images/buildroot/32bit/overlay/etc/init.d/S99PBA.sh
+++ b/images/buildroot/32bit/overlay/etc/init.d/S99PBA.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 clear
 /sbin/linuxpba 2>/tmp/pbaerror.log
+sleep 5

--- a/images/buildroot/64bit/overlay/etc/init.d/S99PBA.sh
+++ b/images/buildroot/64bit/overlay/etc/init.d/S99PBA.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 clear
 /sbin/linuxpba 2>/tmp/pbaerror.log
+sleep 5

--- a/images/getresources
+++ b/images/getresources
@@ -2,9 +2,28 @@
 set -x
 ## Get version information
 . conf
+set -x
+function die {
+echo An error has occurred!  Please fix this and start over!
+exit 99
+}
 ## Make a clean start
 rm -rf scratch
 mkdir scratch
 cd scratch
-wget https://www.kernel.org/pub/linux/utils/boot/syslinux/${SYSLINUX}.tar.xz
+wget https://www.kernel.org/pub/linux/utils/boot/syslinux/${SYSLINUX}.tar.xz || die
 tar xf ${SYSLINUX}.tar.xz 
+
+## Moved the "fetch buildroot" work here; was previously in ./buildpbaroot for unknown $reason
+## Seemed reasonable to get resources in the getresources script.
+#
+# We don't need to rm - rf buildroot since we already removed its parent directory 'scratch' above.
+#rm -rf buildroot
+git clone ${BUILDROOT} || die
+cd buildroot
+git checkout -b PBABUILD ${BUILDROOT_TAG}  || die
+git reset --hard
+git clean -df
+
+## Go back where we started
+cd ../..

--- a/linux/PSIDRevert_LINUX.txt
+++ b/linux/PSIDRevert_LINUX.txt
@@ -7,13 +7,13 @@ optional steps 0.b & 0.c will do this:
 0.b chmod 0744 /sys/module/libata/parameters/allow_tpm
 0.b echo "1" > /sys/module/libata/parameters/allow_tpm
 
-1. setutil-cli --scan    <- SCAN to find Opal Drive (you should see Yes next the the drive
+1. sedutil-cli --scan    <- SCAN to find Opal Drive (you should see Yes next the the drive
                      your working with.
-2. setutil-cli --query /dev/sd? <--this will show the Opal status look at the locking
+2. sedutil-cli --query /dev/sd? <--this will show the Opal status look at the locking
                                                feature and see if it is Locked = Y
                                                or LockingEnabled = Y that's a good
                                                 sign that this should work
-3.setutil-cli --yesIreallywanttoERASEALLmydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd?
+3.sedutil-cli --yesIreallywanttoERASEALLmydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd?
 
 4.  You should see INFO: revertTper completed successfully.
     If you get a message that says NOT_AUTHORIZED you entered the PSID wrong.
@@ -21,7 +21,7 @@ optional steps 0.b & 0.c will do this:
 If it doesn't work please execute the command in step 3 with a -vvvvv (5 v's) as the first option
 redirecting the output to a file and send it back to me.
 example:
-setutil-cli -vvvvv --yesIreallywanttoERASEALLmydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd? > revertlog.txt
+sedutil-cli -vvvvv --yesIreallywanttoERASEALLmydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd? > revertlog.txt
 
 Hope this helps.
 ********************************************************************
@@ -31,7 +31,7 @@ The following is a sanitized log of the commands and expected responses.
 r0m30@r0m30-PC:~$ sudo -s
 root@r0m30-PC:~# chmod 0744 /sys/module/libata/parameters/allow_tpm
 root@r0m30-PC:~# echo "1" > /sys/module/libata/parameters/allow_tpm
-root@r0m30-PC:~# ./setutil-cli --scan
+root@r0m30-PC:~# ./sedutil-cli --scan
 
 Scanning for Opal 2.0 compliant disks
 /dev/sd0  No  ATA     KINGSTON SV100S21205 
@@ -44,7 +44,7 @@ Scanning for Opal 2.0 compliant disks
 /dev/sd7  No  Generic-MS/MS-Pro       1.00 
 /dev/sd8  Yes ATA     Crucial_CT120M50MU05 
 No more disks present ending scan
-root@r0m30-PC:~# ./setutil-cli --query /dev/sd8
+root@r0m30-PC:~# ./sedutil-cli --query /dev/sd8
 /dev/sd8 ATA ATA     Crucial_CT120M50MU05 
 
 TPer function (0x0001)
@@ -60,7 +60,7 @@ DataStore function (0x0202)
 OPAL 2.0 function (0x0203)
     Base comID = 0x1000, Initial PIN = 0x0, Reverted PIN = 0x0, comIDs = 1
     Locking Admins = 4, Locking Users = 9, Range Crossing = N
-root@r0m30-PC:~# ./setutil-cli --yesIreallywanttoERASE*ALL*mydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd8
+root@r0m30-PC:~# ./sedutil-cli --yesIreallywanttoERASEALLmydatausingthePSID <PSIDALLCAPSNODASHES> /dev/sd8
 - 01:14:10.996 INFO: Performing a PSID Revert on /dev/sd8 with password <PSIDALLCAPSNODASHES>
 - 01:14:11.165 INFO: revertTper completed successfully
 root@r0m30-PC:~# 

--- a/windows/PSIDRevert_WINDOWS.txt
+++ b/windows/PSIDRevert_WINDOWS.txt
@@ -11,7 +11,8 @@
     If you get a message that says NOT_AUTHORIZED you entered the PSID wrong.
 
 If it doesn't work please execute the command in step 3 with a -vvvvv (5 v's) as the first option and
-redirect the output to a file and send it back to me.
+redirect the output to a file and post an issue on the SEDutil GitHub site.  NOTE that under Windows
+the -vvvvv option may not work in current/recent builds.
 example:
 sedutil-cli -vvvvv --yesIreallywanttoERASEALLmydatausingthePSID <YOURPSID> \\.\PhysicalDrive? > revertlog.txt 2>&1
 
@@ -49,7 +50,7 @@ OPAL 2.0 function (0x0203)
     Base comID = 0x1000, Initial PIN = 0x0 , Reverted PIN = 0x0 , comIDs = 1
     Locking Admins = 4, Locking Users = 9, Range Crossing = N
 
-U:\sedutil-cli\Release>sedutil-cli --yesIreallywanttoERASE*ALL*mydatausingthePSID PSIDALLCAPSNODASHES \\.\PhysicalDrive3
+U:\sedutil-cli\Release>sedutil-cli --yesIreallywanttoERASEALLmydatausingthePSID PSIDALLCAPSNODASHES \\.\PhysicalDrive3
 - 01:59:13.000 INFO: Performing a PSID Revert on \\.\PhysicalDrive3 with password PSIDALLCAPSNODASHES
 - 01:59:13.171 INFO: revertTper completed successfully
 


### PR DESCRIPTION
This commit/pull request fixes small typos in several files and makes small changes to behavior
that this developer found useful.

Colorized text (Red for failure, green for unlocked) when LinuxPBA runs
	modified:   LinuxPBA/UnlockSEDs.cpp
Added "sleep 5" after LinuxPBA runs, so that users can view unlock success or failure
(particularly useful with multiple disks being unlocked)
	modified:   images/buildroot/32bit/overlay/etc/init.d/S99PBA.sh
	modified:   images/buildroot/64bit/overlay/etc/init.d/S99PBA.sh

Typo fixes as well as changes to move "clone buildroot" into the getresources script
	modified:   images/buildpbaroot
	modified:   images/buildrescue
	modified:   images/getresources

Typo fixes, including all the changes from Pull Request 254 (jessehui)
	modified:   linux/PSIDRevert_LINUX.txt
	modified:   windows/PSIDRevert_WINDOWS.txt