### PR TITLE
ISO file builder for Rescue64 (UEFI) + GRUB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,9 +170,6 @@ config.h
 config.h.in
 config.status
 Makefile
-sedutil-*.tar.*
-linuxpba
-sedutil-cli
 
 # GCC
 .deps/
@@ -180,6 +177,9 @@ sedutil-cli
 .dirstamp
 
 # project specific files
+sedutil-*.tar.*
+linuxpba
+sedutil-cli
 *.VC.opendb
 *.lnk
 /dist/
@@ -190,6 +190,8 @@ Doxygen/
 /images/*/*
 !/images/buildroot/
 !/images/buildroot/*
+!/images/isoFiles/
+!/images/isoFiles/*
 /LinuxPBA/dist/
 /linux/CLI/dist/
 # inno installer output

--- a/images/isoFiles/buildgrub
+++ b/images/isoFiles/buildgrub
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+function die {
+echo An error has occurred!  Please fix this and start over!
+exit 99
+}
+
+set -x
+. isogrubconf
+
+## Checkout defined GRUB2 version and build it for UEFI x86-64.
+
+## This can pretty obviously be overridden/skipped if all the correct packages of a sufficiently
+## recent GRUB2 are installed on the build host - YMMV.
+
+git clone $GRUBGIT || die
+mv grub $GRUBVER
+cd $GRUBVER
+git checkout --quiet $GRUBVER
+
+# Put a copy of the bootstrap output into (new) buildlog file for reference but also print to screen
+set +x
+echo -e "\nRunning bootstrap in $GRUBVER directory\n" 
+echo -e "\nRunning bootstrap in $GRUBVER directory\n=-=-=-=-=-=\n" > ${GRUBVER}-buildlog
+set -x
+./bootstrap | tee -a ${GRUBVER}-buildlog
+
+## Put a copy of the configure output into buildlog file for reference but also print to screen
+set +x
+echo -e "\nRunning configure in $GRUBVER directory\n" 
+echo -e "\nRunning configure in $GRUBVER directory\n=-=-=-=-=-=\n" >> ${GRUBVER}-buildlog
+set -x
+./configure --with-platform=efi | tee -a ${GRUBVER}-buildlog
+
+## Add build results to buildlog file but print errors to screen
+set +x
+echo -e "\nBuilding $GRUBVER\n=-=-=-=-=-=\n" >> ${GRUBVER}-buildlog 
+echo Building $GRUBVER - output will go to ${GRUBVER}-buildlog 
+echo -e "\tand only warnings/errors will be printed.\n"
+set -x
+make all >> ${GRUBVER}-buildlog
+
+## Wrap up
+set +x
+cd ..
+echo 
+echo "Done (unless fatal errors occurred above - some compile-time warnings in GRUB are expected)."
+echo "Binaries should be in ${GRUBVER}/ for use in building Rescue64 UEFI ISO"
+echo "      with EFI-flavored modules in ${GRUBVER}/grub-core/ ."
+

--- a/images/isoFiles/buildiso
+++ b/images/isoFiles/buildiso
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+function die {
+echo An error has occurred!  Please fix this and start over!
+exit 99
+}
+
+## Preparatory work:
+## Source config
+. isogrubconf
+
+BUILDIMG="RESCUE64-${VERSIONINFO}.img"
+
+## Uncomment the two lines below, and comment out the following line, if doing multiple
+## runs to test new ISO etc.
+#now_datetime="$(date +%Y%m%d_%H%M)"
+#new_iso="sedutil-${VERSIONINFO}-Rescue64UEFIgrub_${now_datetime}.iso"
+new_iso="sedutil-${VERSIONINFO}-Rescue64UEFIgrub.iso"
+
+
+## Check for prereqs
+hash xorriso 2>/dev/null ||
+	{ echo >&2 "ISO build script requires xorriso but it's not available."; exit 1;}
+[ -f ../RESCUE64/${BUILDIMG}.gz ] || { echo " prereqs are not available "; exit 1; }
+[ -f grub-SEDutil.cfg ] || { echo " prereqs are not available "; exit 1; }
+
+set -x
+## Clean old directories and set up new ones
+#[ -d scratch/${GRUBVER} ] && rm -rf scratch/${GRUBVER}
+[ -d scratch ] && rm -rf scratch
+
+mkdir scratch
+## Copy RESCUE64 image over from its build directory
+## gzip -d the RESCUE64 image
+
+cp ../RESCUE64/${BUILDIMG}.gz . || die
+gzip -d ${BUILDIMG}.gz || die
+
+## grub command line pieced together from multiple sources including
+##     wiki.archlinux.org/index.php/GRUB/Tips_and_tricks
+## NOTE that as written this requires that GRUB v2.04 source was downloaded (cloned) and built
+## locally - if the ISO buildhost is Ubuntu 18.04.3 LTS or similar then this was the cleanest
+## way to get the 2.04 GRUB that includes Secure Boot functions.
+## Also needs "mtools" which should be installed standard on Ubuntu desktops.
+
+./grub-2.04/grub-mkstandalone \
+	--format=x86_64-efi \
+	--output=./scratch/grubx64_standalone.efi \
+	--modules="shim_lock tpm part_gpt part_msdos all_video gfxterm" \
+	--directory=./grub-2.04/grub-core \
+	--locales="en@quot" --fonts="" --themes="" \
+	"boot/grub/grub.cfg=grub-SEDutil.cfg"
+
+## Now create a small IMG file to contain just the standalone Grub2.
+dd if=/dev/zero of=./scratch/efiboot.img bs=1M count=4
+mkfs.vfat ./scratch/efiboot.img
+mmd -i ./scratch/efiboot.img EFI EFI/boot EFI/boot/grub
+mcopy -i ./scratch/efiboot.img ./scratch/grubx64_standalone.efi ::EFI/boot/bootx64.efi
+mcopy -i ./scratch/efiboot.img grub-SEDutil.cfg ::EFI/boot/grub/grub.cfg
+
+## The efiboot.img file above was manipulated without ever mounting it, so unlike the
+# other img/ISO files we don't have to unmount it.
+
+# Mount the RESCUE64 image (already UEFI) and remaster slightly with the new efiboot.img file.
+LOOPDEV=`sudo losetup --show -f -o 1048576 ${BUILDIMG}`
+
+if [ ! -d image ]; then
+   mkdir image
+fi
+sudo mount $LOOPDEV image
+sudo chmod 777 image
+
+sudo cp scratch/efiboot.img image/EFI/boot
+
+# And now that that's done, let's also put the "real" grub.cfg file where it goes
+sudo cp grub-SEDutil.cfg image/EFI/boot/grub.cfg
+
+## NB for future edits:  There's at least one extra copy of the grub-SEDutil.cfg file ending up
+## in the final ISO (extraneous/not needed) but it's tiny and doesn't break anything so for
+## now just leave it.
+
+echo Building "$new_iso"
+xorriso \
+	-as mkisofs \
+	-iso-level 3 \
+	-full-iso9660-filenames \
+	-volid 'SEDutil Rescue64 boot' \
+	-eltorito-alt-boot \
+	    -e EFI/boot/efiboot.img \
+	    -no-emul-boot -isohybrid-gpt-basdat \
+	-output "$new_iso" \
+	image
+
+## Cleanup your mess
+sudo umount image
+sudo losetup -d $LOOPDEV
+rm -f ${BUILDIMG}

--- a/images/isoFiles/grub-SEDutil.cfg
+++ b/images/isoFiles/grub-SEDutil.cfg
@@ -1,0 +1,12 @@
+GRUB_GFXMODE=2560x1440x32,1920x1080x32,1200x800x32,1024x780x16,800x600x32,800x600x16,auto
+
+menuentry "SEDutil UEFI64 Rescue" {
+	insmod part_gpt
+	set root=(cd0)
+	##set gfxpayload=1280x1024x16,1280x1024
+	set gfxpayload=keep
+	##linuxefi	/EFI/boot/bzImage loglevel=0 libata.allow_tpm=1 nomodeset text
+	##initrdefi	/EFI/boot/rootfs.cpio.xz
+	linux		/EFI/boot/bzImage loglevel=0 libata.allow_tpm=1 video=vesa:off text
+	initrd		/EFI/boot/rootfs.cpio.xz
+}

--- a/images/isoFiles/isogrubconf
+++ b/images/isoFiles/isogrubconf
@@ -1,0 +1,12 @@
+## Versioning to be consistent with other build scripts
+VERSIONINFO=`git describe --dirty`  || VERSIONINFO=tarball
+
+## We chose GRUB, and specifically v2.04, for documented Secure Boot support.
+## Meanwhile Ubuntu 18.04.3 LTS and Buildroot target 2019.02.6 are both still tied to v2.02
+## so we can't easily use OS-level packages or any binaries already built as part of Buildroot.
+
+GRUBGIT=https://git.savannah.gnu.org/git/grub.git
+## For whatever reason, older grub versions are tagged in the repo with bare version number but
+## as of 2.02 they're tagged both ways (?!) and as of 2.04 only as "grub-${numeric}".
+GRUBVER=grub-2.04
+


### PR DESCRIPTION
This is a standalone set of files in `images/isoFiles/` that adds a capability to take any
Rescue64 (nominally UEFI) .img.gz file created by the normal `./buildrescue Rescue64` and
turn it into a UEFI-bootable ISO image - no CSM required.  The "xorriso" utility is used to
remaster the Rescue64 .img file into an ISO.  (NOTE:  "mtools" package also must be installed
on the host, to allow `mmd` and `mcopy` utils to be used to manipulate the `efiboot.img` file.

Primary reason for this was to allow Rescue images on CD for environments that avoid USB
and/or like to have dedicated media that can't get overwritten.

Secondary purpose was to test the ability of GRUB v2.04 to support Trusted Boot with built-in
`shim_lock` modules etc. and without requiring the user/sysadmin to perform additional
cryptographic/cert signing.  That part is untested.

This set of scripts is tested against DTA SEDutil 1.15.1 and makes no changes to the normal
build process, but simply adds a "cd" then two additional steps after the Rescue64 image is built:
```
    cd isoFiles
    ./buildgrub
    ./buildiso
```