### PR TITLE
Fix: JMicron JMS583 USB-NVMe bridge support

### DIFF
--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -271,6 +271,7 @@ void DtaDevLinuxSata::identify(OPAL_DiskInfo& disk_info)
 
     if (!(memcmp(nullz.data(), buffer, 512))) {
         disk_info.devType = DEVICE_TYPE_OTHER;
+        identify_SAS(&disk_info);
         return;
     }
     IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;

--- a/windows/DtaDiskNVMe.cpp
+++ b/windows/DtaDiskNVMe.cpp
@@ -41,38 +41,39 @@ using namespace std;
 #define StorageAdapterProtocolSpecificProperty (STORAGE_PROPERTY_ID) 49
 
 #define NVME_MAX_LOG_SIZE 4096  // value from random internet search
+#if 0
 typedef enum _STORAGE_PROTOCOL_TYPE {
-	ProtocolTypeUnknown = 0x00,
-	ProtocolTypeScsi,
-	ProtocolTypeAta,
-	ProtocolTypeNvme,
-	ProtocolTypeSd,
-	ProtocolTypeProprietary = 0x7E,
-	ProtocolTypeMaxReserved = 0x7F
+    ProtocolTypeUnknown = 0x00,
+    ProtocolTypeScsi,
+    ProtocolTypeAta,
+    ProtocolTypeNvme,
+    ProtocolTypeSd,
+    ProtocolTypeProprietary = 0x7E,
+    ProtocolTypeMaxReserved = 0x7F
 } STORAGE_PROTOCOL_TYPE, *PSTORAGE_PROTOCOL_TYPE;
 typedef struct _STORAGE_PROTOCOL_SPECIFIC_DATA {
-	STORAGE_PROTOCOL_TYPE ProtocolType;
-	DWORD                 DataType;
-	DWORD                 ProtocolDataRequestValue;
-	DWORD                 ProtocolDataRequestSubValue;
-	DWORD                 ProtocolDataOffset;
-	DWORD                 ProtocolDataLength;
-	DWORD                 FixedProtocolReturnData;
-	DWORD                 Reserved[3];
+    STORAGE_PROTOCOL_TYPE ProtocolType;
+    DWORD                 DataType;
+    DWORD                 ProtocolDataRequestValue;
+    DWORD                 ProtocolDataRequestSubValue;
+    DWORD                 ProtocolDataOffset;
+    DWORD                 ProtocolDataLength;
+    DWORD                 FixedProtocolReturnData;
+    DWORD                 Reserved[3];
 } STORAGE_PROTOCOL_SPECIFIC_DATA, *PSTORAGE_PROTOCOL_SPECIFIC_DATA;
 
 typedef enum _STORAGE_PROTOCOL_NVME_DATA_TYPE {
-	NVMeDataTypeUnknown = 0,
-	NVMeDataTypeIdentify,
-	NVMeDataTypeLogPage,
-	NVMeDataTypeFeature
+    NVMeDataTypeUnknown = 0,
+    NVMeDataTypeIdentify,
+    NVMeDataTypeLogPage,
+    NVMeDataTypeFeature
 } STORAGE_PROTOCOL_NVME_DATA_TYPE, *PSTORAGE_PROTOCOL_NVME_DATA_TYPE;
 typedef struct _STORAGE_PROTOCOL_DATA_DESCRIPTOR {
-	DWORD                          Version;
-	DWORD                          Size;
-	STORAGE_PROTOCOL_SPECIFIC_DATA ProtocolSpecificData;
+    DWORD                          Version;
+    DWORD                          Size;
+    STORAGE_PROTOCOL_SPECIFIC_DATA ProtocolSpecificData;
 } STORAGE_PROTOCOL_DATA_DESCRIPTOR, *PSTORAGE_PROTOCOL_DATA_DESCRIPTOR;
-
+#endif
 // End of missing stuff
 
 
@@ -90,7 +91,7 @@ void DtaDiskNVMe::init(const char * devref)
                       0,
                       NULL);
     if (INVALID_HANDLE_VALUE == hDev) 
-		return;
+        return;
     else 
         isOpen = TRUE;
 }
@@ -98,14 +99,14 @@ void DtaDiskNVMe::init(const char * devref)
 uint8_t DtaDiskNVMe::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
                         void * buffer, uint16_t bufferlen)
 {
-	UNREFERENCED_PARAMETER(cmd);
-	UNREFERENCED_PARAMETER(protocol);
-	UNREFERENCED_PARAMETER(comID);
-	UNREFERENCED_PARAMETER(buffer);
-	UNREFERENCED_PARAMETER(bufferlen);
-	LOG(D1) << "Entering DtaDiskNVMe::sendCmd";
-	LOG(D1) << "DtaDiskNVMe::sendCmd Not yet implemented ";
-	return DTAERROR_COMMAND_ERROR;
+    UNREFERENCED_PARAMETER(cmd);
+    UNREFERENCED_PARAMETER(protocol);
+    UNREFERENCED_PARAMETER(comID);
+    UNREFERENCED_PARAMETER(buffer);
+    UNREFERENCED_PARAMETER(bufferlen);
+    LOG(D1) << "Entering DtaDiskNVMe::sendCmd";
+    LOG(D1) << "DtaDiskNVMe::sendCmd Not yet implemented ";
+    return DTAERROR_COMMAND_ERROR;
 }
 
 /** adds the IDENTIFY information to the disk_info structure */
@@ -113,71 +114,71 @@ uint8_t DtaDiskNVMe::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 void DtaDiskNVMe::identify(OPAL_DiskInfo& disk_info)
 {
     LOG(D1) << "Entering DtaDiskNVMe::identify()";
-	PVOID   buffer = NULL;
-	UINT8   *results = NULL;
-	ULONG   bufferLength = 0;
-	DWORD dwReturned = 0;
-	BOOL iorc = 0;
+    PVOID   buffer = NULL;
+    UINT8   *results = NULL;
+    ULONG   bufferLength = 0;
+    DWORD dwReturned = 0;
+    BOOL iorc = 0;
 
-	PSTORAGE_PROPERTY_QUERY query = NULL;
-	PSTORAGE_PROTOCOL_SPECIFIC_DATA protocolData = NULL;
-	PSTORAGE_PROTOCOL_DATA_DESCRIPTOR protocolDataDescr = NULL;
-	//  This buffer allocation is needed because the STORAGE_PROPERTY_QUERY has additional data
-	// that the nvme driver doesn't use ???????????????????
-	/* ****************************************************************************************
-	!!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!!
-	This buffer definition causes the STORAGE_PROTOCOL_SPECIFIC_DATA to OVERLAY the
-	STORAGE_PROPERTY_QUERY.AdditionalParameters field
-	* **************************************************************************************** */
-	bufferLength = FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters)
-		+ sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA) + NVME_MAX_LOG_SIZE;
-	buffer = malloc(bufferLength);
-	/* */
-	if (buffer == NULL) {
-		LOG(E) << "DeviceNVMeQueryProtocolDataTest: allocate buffer failed, exit.\n";
-		return;
-	}
+    PSTORAGE_PROPERTY_QUERY query = NULL;
+    PSTORAGE_PROTOCOL_SPECIFIC_DATA protocolData = NULL;
+    PSTORAGE_PROTOCOL_DATA_DESCRIPTOR protocolDataDescr = NULL;
+    //  This buffer allocation is needed because the STORAGE_PROPERTY_QUERY has additional data
+    // that the nvme driver doesn't use ???????????????????
+    /* ****************************************************************************************
+    !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!!
+    This buffer definition causes the STORAGE_PROTOCOL_SPECIFIC_DATA to OVERLAY the
+    STORAGE_PROPERTY_QUERY.AdditionalParameters field
+    * **************************************************************************************** */
+    bufferLength = FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters)
+        + sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA) + NVME_MAX_LOG_SIZE;
+    buffer = malloc(bufferLength);
+    /* */
+    if (buffer == NULL) {
+        LOG(E) << "DeviceNVMeQueryProtocolDataTest: allocate buffer failed, exit.\n";
+        return;
+    }
 
-	//
-	// Initialize query data structure to get Identify Data.
-	//
-	ZeroMemory(buffer, bufferLength);
+    //
+    // Initialize query data structure to get Identify Data.
+    //
+    ZeroMemory(buffer, bufferLength);
 
-	query = (PSTORAGE_PROPERTY_QUERY)buffer;
-	/* ****************************************************************************************
-	!!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!!
-	This buffer definition causes the STORAGE_PROTOCOL_SPECIFIC_DATA to OVERLAY the
-	STORAGE_PROPERTY_QUERY.AdditionalParameters field
-	* **************************************************************************************** */
-	protocolDataDescr = (PSTORAGE_PROTOCOL_DATA_DESCRIPTOR)buffer;
-	protocolData = (PSTORAGE_PROTOCOL_SPECIFIC_DATA)query->AdditionalParameters;
-	/* */
-	query->PropertyId = StorageAdapterProtocolSpecificProperty;
-	query->QueryType = PropertyStandardQuery;
+    query = (PSTORAGE_PROPERTY_QUERY)buffer;
+    /* ****************************************************************************************
+    !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!! !!DANGER WILL ROBINSON!!
+    This buffer definition causes the STORAGE_PROTOCOL_SPECIFIC_DATA to OVERLAY the
+    STORAGE_PROPERTY_QUERY.AdditionalParameters field
+    * **************************************************************************************** */
+    protocolDataDescr = (PSTORAGE_PROTOCOL_DATA_DESCRIPTOR)buffer;
+    protocolData = (PSTORAGE_PROTOCOL_SPECIFIC_DATA)query->AdditionalParameters;
+    /* */
+    query->PropertyId = StorageAdapterProtocolSpecificProperty;
+    query->QueryType = PropertyStandardQuery;
 
-	protocolData->ProtocolType = ProtocolTypeNvme;
-	protocolData->DataType = NVMeDataTypeIdentify;
-	//	protocolData->ProtocolDataRequestValue = NVME_IDENTIFY_CNS_CONTROLLER;
-	protocolData->ProtocolDataRequestSubValue = 0;
-	protocolData->ProtocolDataOffset = sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA);
-	protocolData->ProtocolDataLength = NVME_MAX_LOG_SIZE;
+    protocolData->ProtocolType = ProtocolTypeNvme;
+    protocolData->DataType = NVMeDataTypeIdentify;
+    //  protocolData->ProtocolDataRequestValue = NVME_IDENTIFY_CNS_CONTROLLER;
+    protocolData->ProtocolDataRequestSubValue = 0;
+    protocolData->ProtocolDataOffset = sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA);
+    protocolData->ProtocolDataLength = NVME_MAX_LOG_SIZE;
 
-	iorc = DeviceIoControl(hDev, IOCTL_STORAGE_QUERY_PROPERTY,
-		buffer, bufferLength, buffer, bufferLength, &dwReturned, NULL);
+    iorc = DeviceIoControl(hDev, IOCTL_STORAGE_QUERY_PROPERTY,
+        buffer, bufferLength, buffer, bufferLength, &dwReturned, NULL);
 
 //
 //
 //
     disk_info.devType = DEVICE_TYPE_NVME;
-	results = (UINT8 *)buffer + FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters)
-		+ sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA);
-	results += 4;
-	memcpy(disk_info.serialNum, results, sizeof(disk_info.serialNum));
-	results += sizeof(disk_info.serialNum);
-	memcpy(disk_info.modelNum, results, sizeof(disk_info.modelNum));
-	results += sizeof(disk_info.modelNum);
-	memcpy(disk_info.firmwareRev, results, sizeof(disk_info.firmwareRev));
-	
+    results = (UINT8 *)buffer + FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters)
+        + sizeof(STORAGE_PROTOCOL_SPECIFIC_DATA);
+    results += 4;
+    memcpy(disk_info.serialNum, results, sizeof(disk_info.serialNum));
+    results += sizeof(disk_info.serialNum);
+    memcpy(disk_info.modelNum, results, sizeof(disk_info.modelNum));
+    results += sizeof(disk_info.modelNum);
+    memcpy(disk_info.firmwareRev, results, sizeof(disk_info.firmwareRev));
+    
 
     return;
 }

--- a/windows/DtaDiskUSB.cpp
+++ b/windows/DtaDiskUSB.cpp
@@ -33,7 +33,11 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include "DtaHexDump.h"
 
 using namespace std;
-DtaDiskUSB::DtaDiskUSB() {};
+
+DtaDiskUSB::DtaDiskUSB() {
+	isSAS = 0;
+};
+
 void DtaDiskUSB::init(const char * devref)
 {
     LOG(D1) << "Creating DtaDiskUSB::DtaDiskUSB() " << devref;
@@ -56,6 +60,10 @@ void DtaDiskUSB::init(const char * devref)
 uint8_t DtaDiskUSB::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
                         void * buffer, uint32_t bufferlen)
 {
+    if(isSAS) {
+        return(sendCmd_SAS(cmd, protocol, comID, buffer, bufferlen));
+    }
+
 	LOG(D1) << "Entering DtaDiskUSB::sendCmd";
     DWORD bytesReturned = 0; // data returned
     if (!isOpen) {
@@ -79,7 +87,7 @@ uint8_t DtaDiskUSB::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 	scsi->sd.TimeOutValue = 20;
 	scsi->sd.SenseInfoLength = 32;
 	scsi->sd.CdbLength = 12;
-	scsi->sd.Cdb[0] = 0xa1;
+	scsi->sd.Cdb[0] = 0xa1; //ATA PASS THROUGH
 	scsi->sd.Cdb[9] = (UCHAR) cmd;
 
 	if (IF_RECV == cmd) {
@@ -88,6 +96,9 @@ uint8_t DtaDiskUSB::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 		scsi->sd.Cdb[1] = 4 << 1;  // PIO IN
 		scsi->sd.Cdb[2] = 0x0e;
 		scsi->sd.Cdb[4] = (UCHAR) (bufferlen / 512);
+	    scsi->sd.Cdb[3] = protocol;
+	    scsi->sd.Cdb[7] = ((comID & 0xff00) >> 8); // Commid MSB
+	    scsi->sd.Cdb[6] = (comID & 0x00ff); // Commid LSB
 		
 	}
 	else if (IDENTIFY == cmd) {
@@ -105,13 +116,10 @@ uint8_t DtaDiskUSB::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 		scsi->sd.Cdb[1] = 5 << 1;  // PIO OUT
 		scsi->sd.Cdb[2] = 0x06;
 		scsi->sd.Cdb[4] = (UCHAR)(bufferlen / 512);
+	    scsi->sd.Cdb[3] = protocol;
+	    scsi->sd.Cdb[7] = ((comID & 0xff00) >> 8); // Commid MSB
+	    scsi->sd.Cdb[6] = (comID & 0x00ff); // Commid LSB
 	}
-
-	
-	scsi->sd.Cdb[3] = protocol;
-	scsi->sd.Cdb[7] = ((comID & 0xff00) >> 8); // Commid MSB
-	scsi->sd.Cdb[6] = (comID & 0x00ff); // Commid LSB
-	
  
     DeviceIoControl(hDev, // device to be queried
                     IOCTL_SCSI_PASS_THROUGH_DIRECT, // operation to perform
@@ -126,6 +134,11 @@ uint8_t DtaDiskUSB::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
 
 void DtaDiskUSB::identify(OPAL_DiskInfo& disk_info)
 {
+    identify_SAS(disk_info);
+    if (DEVICE_TYPE_OTHER!=disk_info.devType) {
+    	return;
+	}
+
     LOG(D1) << "Entering DtaDiskUSB::identify()";
 	vector<uint8_t> nullz(512, 0x00);
     void * identifyResp = NULL;
@@ -162,6 +175,151 @@ void DtaDiskUSB::identify(OPAL_DiskInfo& disk_info)
 	_aligned_free(identifyResp);
     return;
 }
+
+uint8_t DtaDiskUSB::sendCmd_SAS(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+                         void * buffer, uint32_t bufferlen)
+{
+	LOG(D1) << "Entering DtaDiskUSB::sendCmd_SAS";
+    DWORD bytesReturned = 0; // data returned
+    if (!isOpen) {
+        LOG(D1) << "Device open failed";
+		return DTAERROR_OPEN_ERR; //disk open failed so this will too
+    }
+    /*
+     * Initialize the SCSI_PASS_THROUGH_DIRECT structures
+     * per windows DOC with the SCSI Command set reference
+     */
+    SDWB * scsi = (SDWB *) scsiPointer;
+    memset(scsi, 0, sizeof (SDWB));
+	scsi->sd.Length = sizeof(SCSI_PASS_THROUGH_DIRECT);
+	scsi->sd.SenseInfoOffset = offsetof(SDWB, sensebytes);
+	scsi->sd.ScsiStatus = 0;
+	scsi->sd.PathId = 0;
+	scsi->sd.TargetId = 0;
+	scsi->sd.Lun = 0;
+	scsi->sd.DataBuffer = buffer;
+	scsi->sd.DataTransferLength = bufferlen;
+	scsi->sd.TimeOutValue = 20;
+	scsi->sd.SenseInfoLength = 32;
+	scsi->sd.CdbLength = 12;
+
+        // initialize SCSI CDB
+    switch(cmd)
+    {
+        default:
+        {
+            return 0xff;
+        }
+        case IF_RECV:
+        {
+			scsi->sd.DataIn = SCSI_IOCTL_DATA_IN;
+            //auto * p = (CScsiCmdSecurityProtocolIn *) &(scsi->sd.Cdb[0]);
+            //p->m_Opcode = p->OPCODE;
+            scsi->sd.Cdb[0] = 0xA2;
+            //p->m_SecurityProtocol = protocol;
+            scsi->sd.Cdb[1] = protocol;
+            //p->m_SecurityProtocolSpecific = SWAP16(comID);
+            scsi->sd.Cdb[2] = ((comID & 0xff00) >> 8); // Commid MSB
+	        scsi->sd.Cdb[3] = (comID & 0x00ff); // Commid LSB
+            //p->m_INC_512 = 1;
+            scsi->sd.Cdb[4] = 0x80;
+            //p->m_AllocationLength = SWAP32(bufferlen/512);
+            uint32_t cnt = bufferlen/512;
+            scsi->sd.Cdb[6] = cnt>>24;
+            scsi->sd.Cdb[7] = cnt>>16;
+            scsi->sd.Cdb[8] = cnt>>8;
+            scsi->sd.Cdb[9] = cnt;
+
+            break;
+        }
+        case IF_SEND:
+        {
+			scsi->sd.DataIn = SCSI_IOCTL_DATA_OUT;
+            //auto * p = (CScsiCmdSecurityProtocolOut *) &(scsi->sd.Cdb[0]);
+            //p->m_Opcode = p->OPCODE;
+            scsi->sd.Cdb[0] = 0xB5;
+            //p->m_SecurityProtocol = protocol;
+            scsi->sd.Cdb[1] = protocol;
+            //p->m_SecurityProtocolSpecific = SWAP16(comID);
+            scsi->sd.Cdb[2] = ((comID & 0xff00) >> 8); // Commid MSB
+	        scsi->sd.Cdb[3] = (comID & 0x00ff); // Commid LSB
+            //p->m_INC_512 = 1;
+            scsi->sd.Cdb[4] = 0x80;
+            //p->m_TransferLength = SWAP32(bufferlen/512);
+            uint32_t cnt = bufferlen/512;
+            scsi->sd.Cdb[6] = cnt>>24;
+            scsi->sd.Cdb[7] = cnt>>16;
+            scsi->sd.Cdb[8] = cnt>>8;
+            scsi->sd.Cdb[9] = cnt;
+            break;
+        }
+        case IDENTIFY:
+        {
+			scsi->sd.DataIn = SCSI_IOCTL_DATA_IN;
+            scsi->sd.Cdb[0] = 0x12; //INQUIRY
+            scsi->sd.Cdb[4] = 0x28; //sizeof(CScsiCmdInquiry_StandardData);     // some incorrect packing happens on Windows
+            break;
+        }
+    }
+	
+    LOG(D4) << "CDB before";
+    IFLOG(D4) DtaHexDump(scsi->sd.Cdb, 12);
+ 
+    DeviceIoControl(hDev, // device to be queried
+                    IOCTL_SCSI_PASS_THROUGH_DIRECT, // operation to perform
+                    scsi, sizeof (SDWB),
+                    scsi, sizeof (SDWB),
+                    &bytesReturned, // # bytes returned
+                    (LPOVERLAPPED) NULL); // synchronous I/O
+     return (scsi->sd.ScsiStatus);
+}
+
+static void safecopy(uint8_t * dst, size_t dstsize, uint8_t * src, size_t srcsize)
+{
+    const size_t size = min(dstsize, srcsize);
+    if (size > 0) memcpy(dst, src, size);
+    if (size < dstsize) memset(dst+size, '\0', dstsize-size);
+}
+
+void DtaDiskUSB::identify_SAS(OPAL_DiskInfo& disk_info)
+{
+    LOG(D1) << "Entering DtaDiskUSB::identify_SAS()";
+	vector<uint8_t> nullz(512, 0x00);
+    void * identifyResp = NULL;
+	identifyResp = _aligned_malloc(MIN_BUFFER_LENGTH, IO_BUFFER_ALIGNMENT);
+    if (NULL == identifyResp) return;
+    memset(identifyResp, 0, MIN_BUFFER_LENGTH);
+    uint8_t iorc = sendCmd_SAS(IDENTIFY, 0x00, 0x0000, identifyResp, MIN_BUFFER_LENGTH);
+
+    if (0x00 != iorc) {
+        LOG(D) << "IDENTIFY Failed " << (uint16_t) iorc;
+    }
+	if (!(memcmp(identifyResp, nullz.data(), 512))) {
+		disk_info.devType = DEVICE_TYPE_OTHER;
+		_aligned_free(identifyResp);
+		return;
+	}
+
+    disk_info.devType = DEVICE_TYPE_USB;
+    isSAS = 1;
+
+    // response is a standard INQUIRY (at least 36 bytes)
+    // some incorrect packing happens on Windows
+    //auto resp = (CScsiCmdInquiry_StandardData *) identifyResp;
+    auto resp = (uint8_t *)identifyResp;
+
+    // fill out disk info fields
+    //safecopy(disk_info.serialNum, sizeof(disk_info.serialNum), resp->m_T10VendorId, sizeof(resp->m_T10VendorId));
+    safecopy(disk_info.serialNum, sizeof(disk_info.serialNum), resp+0x8, 8);
+    //safecopy(disk_info.firmwareRev, sizeof(disk_info.firmwareRev), resp->m_ProductRevisionLevel, sizeof(resp->m_ProductRevisionLevel));
+    safecopy(disk_info.firmwareRev, sizeof(disk_info.firmwareRev), resp+0x20, 4);
+    //safecopy(disk_info.modelNum, sizeof(disk_info.modelNum), resp->m_ProductId, sizeof(resp->m_ProductId));
+    safecopy(disk_info.modelNum, sizeof(disk_info.modelNum), resp+0x10, 0x10);
+
+	_aligned_free(identifyResp);
+    return;
+}
+
 
 /** Close the filehandle so this object can be delete. */
 DtaDiskUSB::~DtaDiskUSB()

--- a/windows/DtaDiskUSB.h
+++ b/windows/DtaDiskUSB.h
@@ -22,46 +22,50 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include "DtaDiskType.h"
 /** Device specific implementation of disk access functions. */
 typedef struct _SDWB {
-	SCSI_PASS_THROUGH_DIRECT sd;
-	WORD filler;
-	char sensebytes[32];
+    SCSI_PASS_THROUGH_DIRECT sd;
+    WORD filler;
+    char sensebytes[32];
 
 } SDWB;
 
 typedef struct _USB_INQUIRY_DATA {
-	uint8_t fill1[20];
-	char ProductSerial[20];
-	uint8_t fill2[6];
-	char ProductRev[8];
-	char ProductID[40];
+    uint8_t fill1[20];
+    char ProductSerial[20];
+    uint8_t fill2[6];
+    char ProductRev[8];
+    char ProductID[40];
 } USB_INQUIRY_DATA;
 
 class DtaDiskUSB : public DtaDiskType {
 public:
-	DtaDiskUSB();
-	~DtaDiskUSB();
-	/** device specific initialization.
-	* This function should perform the necessary authority and environment checking
-	* to allow proper functioning of the program, open the device, perform an 
-	* identify, add the fields from the identify response to the disk info structure
-	* and if the device is an ATA device perform a call to Discovery0() to complete
-	* the disk_info structure
-	* @param devref character representation of the device is standard OS lexicon
-	*/
-	void init(const char * devref);
-	/** OS specific method to send an ATA command to the device
-	* @param cmd command to be sent to the device
-	* @param protocol security protocol to be used in the command
-	* @param comID communications ID to be used
-	* @param buffer input/output buffer
-	* @param bufferlen length of the input/output buffer
-	*/
-	uint8_t	sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
-		void * buffer, uint32_t bufferlen);
-	/** OS specific routine to send an ATA identify to the device */
-	void identify(OPAL_DiskInfo& disk_info);
+    DtaDiskUSB();
+    ~DtaDiskUSB();
+    /** device specific initialization.
+    * This function should perform the necessary authority and environment checking
+    * to allow proper functioning of the program, open the device, perform an 
+    * identify, add the fields from the identify response to the disk info structure
+    * and if the device is an ATA device perform a call to Discovery0() to complete
+    * the disk_info structure
+    * @param devref character representation of the device is standard OS lexicon
+    */
+    void init(const char * devref);
+    /** OS specific method to send an ATA command to the device
+    * @param cmd command to be sent to the device
+    * @param protocol security protocol to be used in the command
+    * @param comID communications ID to be used
+    * @param buffer input/output buffer
+    * @param bufferlen length of the input/output buffer
+    */
+    uint8_t sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+        void * buffer, uint32_t bufferlen);
+    /** OS specific routine to send an ATA identify to the device */
+    void identify(OPAL_DiskInfo& disk_info);
+    uint8_t sendCmd_SAS(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
+            void * buffer, uint32_t bufferlen);
+    void identify_SAS(OPAL_DiskInfo& disk_info);
 private:
-	void * scsiPointer;
-	HANDLE hDev; /**< Windows device handle */
-	uint8_t isOpen = FALSE;
+    void * scsiPointer;
+    HANDLE hDev; /**< Windows device handle */
+    uint8_t isOpen = FALSE;
+    int isSAS; /* The device is sas */
 };


### PR DESCRIPTION
The JMS583 firmware supports SCSI SECURITY PROTOCOL IN/OUT commands (relaying them to NVMe side correctly), but it also handles the ATA PASS THROUGH command (in a vendor-specific way, implementing an NVMe pass through), so sedutil gets an empty response to ATA PASS THROUGH (but no command error) and treats the drive as SATA w/o OPAL support without trying the SCSI method.
This patch adds probing the SCSI method in case of empty ATA PASS THROUGH response, so the drive gets detected as SAS at the end and works correctly.
