### PR TITLE
DtaAnnotatedDump: Add typedef name to the union

### DIFF
--- a/Common/DtaAnnotatedDump.h
+++ b/Common/DtaAnnotatedDump.h
@@ -20,7 +20,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma pack(push,1)
 
-typedef union
+typedef union CAtomHeader_t
 {
     // four bytes in big endian (network) byte order
     uint8_t     all[4];


### PR DESCRIPTION
This is found with clang
error: anonymous non-C-compatible type given name for linkage purposes by
typedef declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]
| typedef union
|              ^
|               CAtomHeader

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>