### PR TITLE
GitVersion.sh: Make script simpler and more portable

### DIFF
--- a/linux/GitVersion.sh
+++ b/linux/GitVersion.sh
@@ -1,9 +1,7 @@
-#!/bin/bash 
+#!/bin/sh
 #set -x
-GIT=`which git`
-if [ "x"${GIT} == "x" ]; then
-	echo "#define GIT_VERSION \"tarball\""
+if command -v git >/dev/null; then
+	echo "#define GIT_VERSION  \"$(git describe --dirty)\""
 else
-	GITVER=`git describe --dirty`
-	echo "#define GIT_VERSION " \"$GITVER\"
+	echo '#define GIT_VERSION "tarball"'
 fi


### PR DESCRIPTION
- No need to use bash for simple script, more portable with /bin/sh when the content is POSIX anyway
- Use command instead of which and string comparison to see if git executable exists
- Do not double quote static strings
- Use contemporary $() instead of deprecated backtick syntax

Signed-off-by: Joakim Roubert <joakim.roubert@gmail.com>