### PR TITLE
include missing <cstdint>

### DIFF
--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -21,6 +21,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef _DTAOPTIONS_H
 #define	_DTAOPTIONS_H
 
+#include <cstdint>
 /** Output modes */
 typedef enum _sedutiloutput {
 	sedutilNormal,


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>