### PR TITLE
Fix build with GCC 13

### DIFF
--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -21,6 +21,8 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef _DTAOPTIONS_H
 #define	_DTAOPTIONS_H
 
+#include <stdint.h>
+
 /** Output modes */
 typedef enum _sedutiloutput {
 	sedutilNormal,


### PR DESCRIPTION
As in previous versions, libstdc++ in GCC 13 has trimmed internal inclusion of standard headers, necessitating their proper inclusion when used:

https://gcc.gnu.org/gcc-13/porting_to.html

Note that this is the bare minimum change for this to compile with GCC 13, based on how this header is used internally etc.  It is technically more correct to explicitly include this header in every file that uses it, but that is left as an exercise for the reader.
