### PR TITLE
Allow read-only mode on Linux for ATA drives

### DIFF
--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -73,12 +73,12 @@ bool DtaDevLinuxSata::init(const char * devref)
     }
 
     if ((fd = open(devref, O_RDWR)) < 0) {
-        isOpen = FALSE;
         // This is a D1 because diskscan looks for open fail to end scan
         LOG(D1) << "Error opening device in write mode; dev ref: " << devref << " FD: " << (int32_t) fd << " errno: " << errno;
-        if ((fd = open(devref, O_RD)) < 0) {
+        if ((fd = open(devref, O_RDONLY)) < 0) {
             LOG(D1) << "Error opening device in read mode; dev ref: " << devref << " FD: " << (int32_t) fd << " errno: " << errno;
         } else {
+            isOpen = TRUE;
             LOG(E) << "You do not have permission to access the raw disk in write mode, but you can access it in read mode";
             LOG(E) << "Be extra careful trying to operate this device";
         }

--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -75,7 +75,13 @@ bool DtaDevLinuxSata::init(const char * devref)
     if ((fd = open(devref, O_RDWR)) < 0) {
         isOpen = FALSE;
         // This is a D1 because diskscan looks for open fail to end scan
-        LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
+        LOG(D1) << "Error opening device in write mode; dev ref: " << devref << " FD: " << (int32_t) fd << " errno: " << errno;
+        if ((fd = open(devref, O_RD)) < 0) {
+            LOG(D1) << "Error opening device in read mode; dev ref: " << devref << " FD: " << (int32_t) fd << " errno: " << errno;
+        } else {
+            LOG(E) << "You do not have permission to access the raw disk in write mode, but you can access it in read mode";
+            LOG(E) << "Be extra careful trying to operate this device";
+        }
         //        if (-EPERM == fd) {
         //            LOG(E) << "You do not have permission to access the raw disk in write mode";
         //            LOG(E) << "Perhaps you might try sudo to run as root";


### PR DESCRIPTION
Background:

I was experimenting with portable T7 SSD from Samsung. I wanted to have an encrypted drive on my RPi, and the only viable way forward (given that RPi doesn't have HW crypto exts) was OPAL - compatible ssd. I successfully compiled sedutil, was really surprised when it recognized T7 as Opal 2.0-compatible SSD. Afterwards, I was able to make it work using the regular set of commands to set up Opal (I needed to erase using PSID first before I could set up Opal for the first time though).

After I rebooted though, sedutil stopped to recognize the SSD as Opal-compatible and returned 0 for status. 
I spent the next several hours trying to do literally everything to unlock it, including hdparm, requesting factory reset tool from Samsung to no avail. I then tried to debug sedutil, and it turned out it failed because it wasn't able to open device in RDWR mode, but it was operating totally fine & getting device properties correctly opening it just in readonly mode.