### PR TITLE
Check MBR Shadow during TakeOwnership

### DIFF
--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -80,6 +80,11 @@ uint8_t DtaDev::MBRDone()
 	LOG(D1) << "Entering DtaDev::MBRDone" << (uint16_t)disk_info.Locking_MBRDone;
 	return disk_info.Locking_MBRDone;
 }
+uint8_t DtaDev::MBRAbsent()
+{
+	LOG(D1) << "Entering DtaDev::MBRAbsent" << (uint16_t)disk_info.Locking_MBRAbsent;
+	return disk_info.Locking_MBRAbsent;
+}
 uint8_t DtaDev::Locked()
 {
 	LOG(D1) << "Entering DtaDev::Locked" << (uint16_t)disk_info.Locking_locked;
@@ -148,6 +153,7 @@ void DtaDev::discovery0()
             disk_info.Locking_lockingSupported = body->locking.lockingSupported;
             disk_info.Locking_MBRDone = body->locking.MBRDone;
             disk_info.Locking_MBREnabled = body->locking.MBREnabled;
+            disk_info.Locking_MBRAbsent = body->locking.MBRAbsent;
             disk_info.Locking_mediaEncrypt = body->locking.mediaEncryption;
             break;
         case FC_GEOMETRY: /* Geometry Features */
@@ -240,6 +246,7 @@ void DtaDev::puke()
 			<< "LockingSupported = " << (disk_info.Locking_lockingSupported ? "Y, " : "N, ");
 		cout << "MBRDone = " << (disk_info.Locking_MBRDone ? "Y, " : "N, ")
 			<< "MBREnabled = " << (disk_info.Locking_MBREnabled ? "Y, " : "N, ")
+			<< "MBRAbsent = " << (disk_info.Locking_MBRAbsent ? "Y, " : "N, ")
 			<< "MediaEncrypt = " << (disk_info.Locking_mediaEncrypt ? "Y" : "N")
 			<< std::endl;
 	}

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -50,6 +50,8 @@ public:
 	uint8_t MBREnabled();
 	/** Is the MBRDone flag set */
 	uint8_t MBRDone();
+	/** Is the MBRAbsent flag set */
+	uint8_t MBRAbsent();
 	/** Is the Locked flag set */
 	uint8_t Locked();
 	/** Is the Locking SP enabled */

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevOpal.cpp
+++ b/Common/DtaDevOpal.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevOpal.cpp
+++ b/Common/DtaDevOpal.cpp
@@ -70,13 +70,8 @@ uint8_t DtaDevOpal::initialSetup(char * password)
 		LOG(E) << "Initial setup failed - unable to set global locking range RW";
 		return lastRC;
 	}
-	if ((lastRC = setMBRDone(1, password)) != 0){
-		LOG(E) << "Initial setup failed - unable to Enable MBR shadow";
-		return lastRC;
-	}
-	if ((lastRC = setMBREnable(1, password)) != 0){
-		LOG(E) << "Initial setup failed - unable to Enable MBR shadow";
-		return lastRC;
+	if (!MBRAbsent()) {
+		setMBREnable(1, password);
 	}
 	
 	LOG(I) << "Initial setup of TPer complete on " << dev;

--- a/Common/DtaStructures.h
+++ b/Common/DtaStructures.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaStructures.h
+++ b/Common/DtaStructures.h
@@ -83,8 +83,8 @@ typedef struct _Discovery0LockingFeatures {
     uint8_t version : 4;
     uint8_t length;
     /* Big endian
-    uint8_t reserved01 : 1;
     uint8_t reserved02 : 1;
+    uint8_t MBRAbsent : 1;
     uint8_t MBRDone : 1;
     uint8_t MBREnabled : 1;
     uint8_t mediaEncryption : 1;
@@ -98,7 +98,7 @@ typedef struct _Discovery0LockingFeatures {
     uint8_t mediaEncryption : 1;
     uint8_t MBREnabled : 1;
     uint8_t MBRDone : 1;
-    uint8_t reserved01 : 1;
+    uint8_t MBRAbsent : 1;
     uint8_t reserved02 : 1;
 
     uint32_t reserved03;
@@ -306,6 +306,7 @@ typedef struct _OPAL_DiskInfo {
     uint8_t Locking_lockingSupported : 1;
     uint8_t Locking_MBRDone : 1;
     uint8_t Locking_MBREnabled : 1;
+    uint8_t Locking_MBRAbsent : 1;
     uint8_t Locking_mediaEncrypt : 1;
     uint8_t Geometry_align : 1;
     uint64_t Geometry_alignmentGranularity;


### PR DESCRIPTION
At this point in time, utility is taking ownership with provided password successfully with two classes of drives.
  1.  That supports MBRShadowing
  2.  That does not support MBRShadowing

However, for those drives that does not support MBRSHadowing, it reports error and tool's return code is non zero despite taking ownership.

This patch is to improve experience by checking MBRShadow capability (decoded with discovery0) prior to enable MBR.