### PR TITLE
Generate Random bytes feature

### DIFF
--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -283,6 +283,9 @@ public:
 	virtual uint8_t exec(DtaCommand * cmd, DtaResponse & resp, uint8_t protocol = 0x01) = 0;
 	/** return the communications ID to be used for sessions to this device */
 	virtual uint16_t comID() = 0;
+	/* Print random number of bytes specified in the argument */
+	virtual uint8_t printRandomBytes(uint8_t num_of_bytes) = 0;
+
 	bool no_hash_passwords; /** disables hashing of passwords */
 	sedutiloutput output_format; /** standard, readable, JSON */
 protected:

--- a/Common/DtaDevEnterprise.cpp
+++ b/Common/DtaDevEnterprise.cpp
@@ -1677,6 +1677,11 @@ uint8_t DtaDevEnterprise::objDump(char *sp, char * auth, char *pass,
 	LOG(D1) << "Exiting DtaDevEnterprise::objDump";
 	return 0;
 }
+
+uint8_t DtaDevEnterprise::printRandomBytes(uint8_t num_of_bytes) {
+	LOG(E) << "printRandomBytes() is not implemented for Enterprise";
+	return -1;
+}
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/Common/DtaDevEnterprise.cpp
+++ b/Common/DtaDevEnterprise.cpp
@@ -1,6 +1,7 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
 This software is Copyright 2017 Spectra Logic Corporation
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevEnterprise.h
+++ b/Common/DtaDevEnterprise.h
@@ -205,6 +205,10 @@ public:
 	uint8_t rawCmd(char *sp, char *hexauth, char *pass,
 		char *hexinvokingUID, char *hexmethod, char *hexparms);
 
+	/** Print random number of bytes
+	 * @param num_of_bytes Number of bytes to print
+	 */
+	uint8_t printRandomBytes(uint8_t num_of_bytes);
 protected:
 	uint8_t getDefaultPassword();
 private:

--- a/Common/DtaDevEnterprise.h
+++ b/Common/DtaDevEnterprise.h
@@ -1,6 +1,7 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
 This software is Copyright 2017 Spectra Logic Corporation
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevGeneric.cpp
+++ b/Common/DtaDevGeneric.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevGeneric.cpp
+++ b/Common/DtaDevGeneric.cpp
@@ -102,6 +102,7 @@ uint16_t DtaDevGeneric::comID()
 uint8NOCODE(exec,DtaCommand * cmd, DtaResponse & resp, uint8_t protocol)
 uint8NOCODE(objDump,char *sp, char * auth, char *pass,char * objID)
 uint8NOCODE(rawCmd,char *sp, char * auth, char *pass,char *invoker, char *method, char *plist)
+uint8NOCODE(printRandomBytes,uint8_t num_of_bytes)
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/Common/DtaDevGeneric.h
+++ b/Common/DtaDevGeneric.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevGeneric.h
+++ b/Common/DtaDevGeneric.h
@@ -224,4 +224,6 @@ public:
 	 uint8_t exec(DtaCommand * cmd, DtaResponse & resp, uint8_t protocol = 1) ;
          /** return the communications ID to be used for sessions to this device */
 	 uint16_t comID() ;
+
+	 uint8_t printRandomBytes(uint8_t num_of_bytes);
 };

--- a/Common/DtaDevOpal.cpp
+++ b/Common/DtaDevOpal.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevOpal.h
+++ b/Common/DtaDevOpal.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaDevOpal.h
+++ b/Common/DtaDevOpal.h
@@ -260,6 +260,11 @@ public:
          */
 	uint8_t rawCmd(char *sp, char * auth, char *pass,
 		char *invoker, char *method, char *plist);
+
+	/** Print random number of bytes
+	 * @param num_of_bytes Number of bytes to print
+	 */
+	uint8_t printRandomBytes(uint8_t num_of_bytes);
 protected:
         /** Primitive to handle the setting of a value in the locking sp.
          * @param table_uid UID of the table 

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -95,6 +95,9 @@ void usage()
     printf("                                revert the device using the PSID *ERASING* *ALL* the data \n");
     printf("--printDefaultPassword <device>\n");
     printf("                                print MSID \n");
+    printf("--printRandomBytes <count> <device>\n");
+    printf("                                Print random generated <count> bytes from <device> \n");
+    printf("                                <count> should be between 1 to 32 (both inclusive) \n");
     printf("\n");
     printf("Examples \n");
     printf("sedutil-cli --scan \n");
@@ -511,6 +514,7 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
 			END_OPTION
 		BEGIN_OPTION(objDump, 5) i += 4; OPTION_IS(device) END_OPTION
         BEGIN_OPTION(printDefaultPassword, 1) OPTION_IS(device) END_OPTION
+		BEGIN_OPTION(printRandomBytes, 2, 2) OPTION_IS(byte_count) OPTION_IS(device) END_OPTION
 		BEGIN_OPTION(rawCmd, 7) i += 6; OPTION_IS(device) END_OPTION
 		else {
             LOG(E) << "Invalid command line argument " << argv[i];

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -44,6 +44,7 @@ typedef struct _DTA_OPTIONS {
 
 	bool no_hash_passwords; /** global parameter, disables hashing of passwords */
 	sedutiloutput output_format;
+	uint8_t byte_count;
 } DTA_OPTIONS;
 /** Print a usage message */
 void usage();
@@ -95,6 +96,7 @@ typedef enum _sedutiloption {
 	validatePBKDF2,
 	objDump,
     printDefaultPassword,
+	printRandomBytes,
 	rawCmd,
 
 } sedutiloption;

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -259,6 +259,15 @@ int main(int argc, char * argv[])
 		LOG(D) << "print default password";
         return d->printDefaultPassword();
         break;
+	case sedutiloption::printRandomBytes:
+	{
+		uint8_t num_of_bytes = atol(argv[opts.byte_count]);
+		LOG(D) << "print random " << num_of_bytes << " byte(s)";
+		if ((num_of_bytes > 0) && (num_of_bytes <= 32))
+			return d->printRandomBytes(num_of_bytes);
+		LOG(E) << "Random byte count between 1 to 32 are supported";
+		break;
+	}
 	case sedutiloption::rawCmd:
 		LOG(D) << "Performing cmdDump ";
 		return d->rawCmd(argv[argc - 7], argv[argc - 6], argv[argc - 5], argv[argc - 4], argv[argc - 3], argv[argc - 2]);

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -1,5 +1,6 @@
 /* C:B**************************************************************************
 This software is Copyright 2014-2017 Bright Plaza Inc. <drivetrust@drivetrust.com>
+This software is Copyright 2023 Nutanix, Inc. <opensource@nutanix.com>
 
 This file is part of sedutil.
 


### PR DESCRIPTION
TCG Storage Architecture Core Specification allows random byte generation as one of the cryptographic operation. This check-in implements printRandomBytes function for Opal drives. It should work for Enterprise drive as well. However, at the time of this writing, we could not procure Enterprise version to validate.

It is an error to have range outside of 1 to 32.