### PR TITLE
linux: search for more than 26 devices

### DIFF
--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -136,6 +136,7 @@ int  DtaDevOS::diskScan()
     {
         while((dirent=readdir(dir))!=NULL) {
             if((!fnmatch("sd[a-z]",dirent->d_name,0)) || 
+                    (!fnmatch("sd[a-z][a-z]",dirent->d_name,0)) ||
                     (!fnmatch("nvme[0-9]",dirent->d_name,0)) ||
                     (!fnmatch("nvme[0-9][0-9]",dirent->d_name,0))
                     ) {


### PR DESCRIPTION
The devices sda through sdz are not enough to cover many storage servers. Match the device handle names that scsi generates after the first 26 devices, too. This gets to a total of 702 possible drives, which ought to be enough for a while.