### PR TITLE
Fix the loadPBAimage option

### DIFF
--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -324,6 +324,11 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
             OPTION_IS(password)
             OPTION_IS(device)
         END_OPTION
+        BEGIN_OPTION(loadPBAimage, 3)
+            OPTION_IS(password)
+            OPTION_IS(pbafile)
+            OPTION_IS(device)
+        END_OPTION
         BEGIN_OPTION(TCGreset, 2)
             TCGRESETTYPEARG(resettype)
             OPTION_IS(device)


### PR DESCRIPTION
This fixes the `--loadPBAimage` being unrecognized (apparently this bit of code got lost during reformatting?); the bug is present in the current latest release.