### PR TITLE
Fix authentication on Enterprise SID password set

### DIFF
--- a/Common/DtaDevEnterprise.cpp
+++ b/Common/DtaDevEnterprise.cpp
@@ -1306,7 +1306,6 @@ uint8_t DtaDevEnterprise::setSIDPassword(char * oldpassword, char * newpassword,
 			LOG(E) << "Unable to create session object ";
 			return DTAERROR_OBJECT_CREATE_FAILED;
 		}
-		session->dontHashPwd();
 		if (!hasholdpwd) session->dontHashPwd();
 		if ((lastRC = session->start(OPAL_UID::OPAL_ADMINSP_UID, oldpassword, user)) != 0) {
 			delete session;


### PR DESCRIPTION
It seems that password changes subsequent to the initial takeover should have the old password sent hashed.

In my testing, the original code would never authenticate for a SID password update. When sending a hashed old password it works fine.
